### PR TITLE
feat: Do not show the header if report is running on an iframe

### DIFF
--- a/library/templates/Report/Report.vue
+++ b/library/templates/Report/Report.vue
@@ -32,10 +32,11 @@
       popup:false
     }),
     props: {
-      // to hide header use this prop
+      // to hide the header use this prop
+      // the header is shown only if the report is not shown in an iframe
       hasHeader: {
         type: Boolean,
-        default: false,
+        default: () => window.location === window.parent.location,
       },
       showSidebar: {
         type: Boolean,


### PR DESCRIPTION
To be able to remove the top header nav when we are running the report in an iframe, I'm changing the default value to false when in an iframe and true otherwise.
We need to remove this prop from here since the default will be true from now on: https://github.com/snyk/snyk-insights-topcoat/blob/main/pages/issues_detail.html#L3