### PR TITLE
feat: add horizontal scroll on table

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -1079,6 +1079,7 @@ export default {
   max-width: inherit;
   max-height: inherit;
   position: relative;
+  overflow-x: scroll;
 }
 
 .spinnerOverlay {


### PR DESCRIPTION
We have been intending to add the horizontal scroll on the table for a while. This is the most basic implementation of that, so that tables with lots of columns aren't squished, or overflowing their container.