### PR TITLE
feat: Adding support for default-value in TSelect and TMultiSelector

### DIFF
--- a/visualizations/frontend/filters/v2/TMultiSelector.vue
+++ b/visualizations/frontend/filters/v2/TMultiSelector.vue
@@ -150,13 +150,16 @@
 				}
 				return attrs;
 			}
-		},
+        },
 		methods: {
             onVisualizationInit() {
 				const initial_value = this.getFilterValue("selected_items");
 
                 if (initial_value) {
                     this.checked = initial_value.split('|');
+                } else if (this.defaultValue) {
+                    this.checked = this.defaultValue.split('|');
+                    this.setFilterValue("selected_items", this.defaultValue);
                 }
             },
 			selectUnselect() {
@@ -168,7 +171,7 @@
 				this.updateUrlParam();
 			},
             updateUrlParam() {
-                this.setFilterValue("selected_items", this.checked.join('|'), true);
+                this.setFilterValue("selected_items", this.checked.join('|'));
             },
             onDropdownOpen() {
                 this.fetchLayerData();

--- a/visualizations/frontend/filters/v2/TSelect.vue
+++ b/visualizations/frontend/filters/v2/TSelect.vue
@@ -100,14 +100,30 @@
                 }
                 return menu;
             },
-			selectedItemLabel() {
-				const selected = this.menu.filter(item => item.value === this.selected_internal)[0]
-				return selected ? selected.title : null;
-			},
-		},
-		methods: {
+            selectedItemLabel() {
+                const selected = this.menu.filter(item => item.value === this.selected_internal)[0]
+
+                if (selected) {
+                    return selected.title;
+                }
+
+                if (this.selected_internal) {
+                    return this.selected_internal;
+                }
+
+                return null;
+            },
+        },
+        methods: {
             onVisualizationInit() {
-                this.selected_internal = this.getFilterValue("dropdown");
+                const initial_value = this.getFilterValue("dropdown");
+
+                if (initial_value) {
+                    this.selected_internal = initial_value;
+                } else if (this.defaultValue) {
+                    this.selected_internal = this.defaultValue;
+                    this.setFilterValue("dropdown", this.defaultValue);
+                }
             },
             selectItem(item) {
                 if (this.selected_internal === item.value && this.isUnselectable) {


### PR DESCRIPTION
We can use `default-value` as a `string` in `<t-multi-selector>` and `<t-select>` to set the value and its corresponding filter state in the URL.

Example:
```html
<t-multi-selector is-expanded default-value="False" t-layer="filter_ignored" t-filter:selected_items="ignored" item-label="Currently Ignored" />
```

```html
<t-select default-value="Severity" t-layer="filter_layer_type" t-filter:dropdown="issue_by" label="Issues By" item-label="Issues_by" />
```