### PR TITLE
Tags filter and fixes

### DIFF
--- a/library/components/TDropdown.vue
+++ b/library/components/TDropdown.vue
@@ -1,8 +1,6 @@
 <template>
 	<div
-		class="relative font-sans cursor-pointer w-max dropdown-filter"
-		@mouseover="setActiveState"
-		@mouseleave="setActiveState($event, false)"
+		class="relative w-auto font-sans cursor-pointer dropdown-filter"
 		ref="dropdownFilter"
 	>
         <div
@@ -13,12 +11,11 @@
         </div>
 		<slot name="outside"></slot>
 		<div
-			v-show="isPopupOpen"
 			ref="popup"
-			class="absolute mt-1 bg-white rounded-lg shadow-md base-dropdown-menu w-max min-w-"
-			:class="alignClass"
+			class="absolute mt-1 bg-white rounded-lg shadow-md base-dropdown-menu w-max"
+			:class="[alignClass, isPopupOpen ? 'h-max': 'h-[0px] opacity-0 overflow-y-hidden']"
 			:style="{ zIndex }"
-            :key="componentKey"
+			@click.stop
 		>
             <slot></slot>
 		</div>
@@ -29,10 +26,6 @@
 	export default {
         props: {
             isActive: {
-                type: Boolean,
-                default: false,
-            },
-			isPersisted: {
                 type: Boolean,
                 default: false,
             },
@@ -48,7 +41,6 @@
 		data: () => ({
 			alignClass: '',
 			isPopupOpen: false,
-            componentKey: '',
 		}),
         computed: {
             activeClass() {
@@ -93,11 +85,6 @@
 				this.$nextTick(() => {
 					this.alignPopup();
 				})
-			},
-			setActiveState(e, state = true) {
-				if (!state && this.isPopupOpen) {
-					return;
-				}
 			},
 			openPopup() {
 				if (this.isPopupOpen) {

--- a/library/components/TExpandable.vue
+++ b/library/components/TExpandable.vue
@@ -14,7 +14,7 @@
                 <slot name="icon"></slot>
             </div>
         </div>
-        <div class="px-2 pt-1" v-show="expanded">
+        <div class="px-2 pt-1" :class="expanded ? 'h-max' : 'h-[0px] opacity-0 overflow-y-hidden'">
             <slot :onExpandable="expanded"></slot>
         </div>
     </div>

--- a/library/templates/Report/ReportHeader.vue
+++ b/library/templates/Report/ReportHeader.vue
@@ -15,7 +15,7 @@
                     </span>
                 </div>
                 <t-dropdown disable-handle-class>
-                    <menu-down-icon slot="handle" class="relative right-1" />
+                    <menu-down-icon slot="handle" />
                     <div class="flex flex-col gap-2 px-2 py-2 md:px-5">
                         <a href="/logout">Logout</a>
                         <a href="https://snyk.io/" class="md:hidden">Go to snyk.io</a>

--- a/visualizations/frontend/filters/v2/TMultiSelector.vue
+++ b/visualizations/frontend/filters/v2/TMultiSelector.vue
@@ -166,7 +166,8 @@
                 if (this.checked.length === this.ids.length) {
                     this.checked = [];
                 } else {
-                    this.checked = this.ids;
+					// Only select what is visible, search can affect this.
+                    this.checked = this.menu.map(i => i.value);
                 }
 				this.updateUrlParam();
 			},

--- a/visualizations/frontend/filters/v2/TTagsInput.vue
+++ b/visualizations/frontend/filters/v2/TTagsInput.vue
@@ -1,0 +1,145 @@
+<template>
+	<div class="t-tags-input max-w-max min-w-full min-h-[43px] relative">
+		<div class="pb-2 font-bold tracking-widest" v-if="label">
+			{{ label.toUpperCase() }}
+		</div>
+		<base-multiple-value-input
+			v-if="isSingleTag"
+			v-model="selectedTags"
+			selection-only
+			:data="tags.length ? tags : tempTags"
+			:loading="loading"
+			:placeholder="placeholder"
+			@update="handleUpdate"
+			display-key="value"
+			value-key="value"
+			@opened="handleOpen"
+		/>
+		<base-tags-input
+			v-else
+			v-model="selectedTags"
+			selection-only
+			:data="tags"
+			:loading="loading"
+			:placeholder="placeholder"
+			@update="handleUpdate"
+			@opened="handleOpen"
+		/>
+	</div>
+</template>
+
+<script>
+	export default {
+		props: {
+			label: {
+				type: String,
+				default: '',
+			},
+			tKeyColumn: {
+				type: String,
+				default: 'KEY',
+			},
+			tValueColumn: {
+				type: String,
+				default: 'VALUE',
+			},
+			isSingleTag: {
+				type: Boolean,
+				default: false,
+			},
+			placeholder: {
+				type: String,
+				default: '',
+			}
+		},
+		data: () => ({
+			is_filter: true,
+			selectedTags: [],
+			tempTags: [], // base-multiple-value-input does not show selected items if `tags` is empty because data is fetched on open.
+		}),
+		computed:{ 
+			tags() {
+				const items = [];
+
+				if (this.rows.length) {
+					for (let row of this.rows) {
+						const key = row[this.tKeyColumn];
+						const value = row[this.tValueColumn];
+						if (key && value) {
+							items.push({
+								key: key.value,
+								value: value.value,
+							})
+						}
+					}
+				}
+				return items;
+			},
+			firstKey() {
+				// Used for single tag
+				if (this.tags.length) {
+					return this.tags[0].key;
+				}
+				
+				if (this.tempTags) {
+					return this.tempTags[0].key;
+				}
+				
+				return null;
+			}
+		},
+		methods: {
+			onVisualizationInit() {
+				const initial_value = this.getFilterValue("selected_items");
+
+				if (initial_value) {
+					const selectedTags = [];
+                    const tempTags = [];
+					const urlTags = initial_value.split('|');
+					
+					for (let item of urlTags) {
+						const splitPair = item.split('_');
+						const key = splitPair.length > 1 ? splitPair[1] : splitPair[0];
+						const value = splitPair[0];
+
+						if (key && value) {
+							if (this.isSingleTag) {
+								selectedTags.push(value);
+								tempTags.push({ key, value })
+							} else {
+								selectedTags.push({ key, value });
+							}
+						}
+					}
+					
+				    this.tempTags = tempTags;
+				    this.selectedTags = selectedTags;
+				}
+			},
+			handleUpdate(items) {
+				const values = [];
+				for (let item of items) {
+					if (this.isSingleTag) {
+						if (!this.firstKey) {
+							break;
+						}
+						values.push(`${item}_${this.firstKey}`);
+					} else {
+						values.push(`${item.value}_${item.key}`);
+					}
+				}
+				this.setFilterValue("selected_items", values.join('|'));
+			},
+			handleOpen() {
+				this.fetchLayerData();
+			},
+		},
+	}
+</script>
+
+<style>
+	.t-tags-input .vue--multiple-value-input__body {
+		position: relative !important;
+		min-width: 100% !important;
+	}
+</style>


### PR DESCRIPTION
What's new
- Tags filter from Product CL.

Fixes:
- Some product CL filters do not work well with `v-show` or `v-if` when used inside a dropdown, used `height: 0px` logic for them instead, which is working great.
- Removed un-used code.

Tags Syntax:
```
<t-tags-input
    t-layer="filter_cve"
    item-label="CVE"
    t-filter:selected_items="cve"
    :is-label-capitalized="true"
    :is-single-tag="true" // If only one tag, use this.
/> 
```