### PR TITLE
fix: Use value for getColumn ids

### DIFF
--- a/visualizations/frontend/filters/v2/TMultiSelector.vue
+++ b/visualizations/frontend/filters/v2/TMultiSelector.vue
@@ -133,12 +133,16 @@
 
                 if (values && titles) {
                     for (let index in values) {
-                        const value = values[index];
+                        const value = values[index] && values[index].toString();
                         const title = titles[index];
+
 						if (this.isSearchable && !title.toLowerCase().includes(this.search.toLowerCase())) {
 							continue;
 						}
-                        menu.push({ value, title });
+
+						if (value && title) {
+							menu.push({ value, title });
+						}
                     }
                 }
                 return menu;

--- a/visualizations/frontend/filters/v2/TMultiSelector.vue
+++ b/visualizations/frontend/filters/v2/TMultiSelector.vue
@@ -124,7 +124,7 @@
             },
             ids() {
 				const column_name = this.tKeyColumn ? this.tKeyColumn : this.findColumnByTag('ids');
-				return this.getColumn(column_name);
+				return this.getColumn(column_name, 'value');
             },
 			menu() {
                 const values = this.ids;


### PR DESCRIPTION
Use `value` instead of `rendered` attribute for `ids`.
Results comes with two attributes: rendered and value.
`value` is the raw value
`rendered` is a formatted version of the `value`.

Examples:
<img width="360" alt="image" src="https://user-images.githubusercontent.com/1915140/183627214-a61188da-46b6-4aa8-a779-e850ade55f30.png">


Related PR: https://github.com/snyk/topcoat-core/pull/487