### PR TITLE
un-removed required loading watcher

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -384,6 +384,9 @@ export default {
     },
   },
   watch: {
+    loading(){
+      this.showSpinner=this.loading
+    },
     internalSelectedItem() {
       this.$emit("update:selectedItem", this.internalSelectedItem);
       this.$emit("selectedItemChanged", this.internalSelectedItem);


### PR DESCRIPTION
I goofed when testing some cleanup for the fix for the “no data” message bug and removed a watcher that I thought was unnecessary but was actually needed. This re-adds the watcher.