### PR TITLE
Add the "rendered" slot prop and updated the "value" slot prop to return the "value" property from the cell object

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -766,38 +766,25 @@ export default {
       return index >= this.startIndex && index < this.endIndex;
     },
     getRawCellValue(row, column) {
-      let cellValue = _.get(
+      const cellValue = _.get(
         row.originalRow,
         column.property,
         column.default_value
       );
-      if (cellValue && typeof cellValue === "object") {
-        if (cellValue.value){
-            cellValue = cellValue.value;
-        } 
-        else cellValue = "";
-      }
-      return cellValue;
+      return cellValue && typeof cellValue === "object" ? cellValue.value : '';
     },
     getCellValue(row, column) {
-      const cellValue = this.getRenderedCellValue(row, column);
       return column.format
-        ? column.format(cellValue, row.originalRow)
-        : cellValue;
+        ? column.format(this.getRenderedCellValue(row, column), row.originalRow)
+        : this.getRenderedCellValue(row, column);
     },
     getRenderedCellValue(row, column){
-        let cellValue = _.get(
+        const cellValue = _.get(
         row.originalRow,
         column.property,
         column.default_value
       );
-      if (cellValue && typeof cellValue === "object") {
-        if (cellValue.rendered){
-            cellValue = cellValue.rendered;
-        } 
-        else cellValue = "";
-      }
-      return cellValue;
+      return cellValue && typeof cellValue === "object" ? cellValue.rendered : '';
     },
     generateHeaderClasses(header, index) {
       let classes = _.camelCase(header);

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -146,6 +146,7 @@
                 :row="row.originalRow"
                 :value="getRawCellValue(row, column)"
                 :rendered_value="getCellValue(row, column)"
+                :rendered="getRenderedCellValue(row, column)"
               >
                 {{ getCellValue(row, column) }}
               </slot>
@@ -771,16 +772,32 @@ export default {
         column.default_value
       );
       if (cellValue && typeof cellValue === "object") {
-        if (cellValue.rendered) cellValue = cellValue.rendered;
+        if (cellValue.value){
+            cellValue = cellValue.value;
+        } 
         else cellValue = "";
       }
       return cellValue;
     },
     getCellValue(row, column) {
-      const cellValue = this.getRawCellValue(row, column);
+      const cellValue = this.getRenderedCellValue(row, column);
       return column.format
         ? column.format(cellValue, row.originalRow)
         : cellValue;
+    },
+    getRenderedCellValue(row, column){
+        let cellValue = _.get(
+        row.originalRow,
+        column.property,
+        column.default_value
+      );
+      if (cellValue && typeof cellValue === "object") {
+        if (cellValue.rendered){
+            cellValue = cellValue.rendered;
+        } 
+        else cellValue = "";
+      }
+      return cellValue;
     },
     generateHeaderClasses(header, index) {
       let classes = _.camelCase(header);


### PR DESCRIPTION
Firefox does not support dates in the format month-day-year, fortunately the back end properly converts that to an iso compatible date in the "value" property. Unfortunately, that value was not available to t-columns, so this adds the "value" to as a slot prop so t-colum

![Screen Shot 2022-08-16 at 4 49 02 PM (2)](https://user-images.githubusercontent.com/78518576/184982754-9b446078-b4c3-4fb2-95e0-b7d005b90c2a.png)
ns can reference it. 

