### PR TITLE
Fixed the vertical scroll when data is loading in a table and the spinner is showing

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -1166,7 +1166,7 @@ export default {
   max-width: inherit;
   max-height: inherit;
   position: relative;
-  min-height: 100px;
+  min-height: 120px;
   overflow-x: scroll;
 }
 
@@ -1178,7 +1178,6 @@ export default {
   bottom: 0;
   left: 0;
   right: 0;
-  min-height: 120px;
 }
 .spinner {
   position: absolute;


### PR DESCRIPTION
To test it is easiest to see the spinner when topcoat-core has been restarted so the data isn't cached.

Previous behavior: there was a vertical scrollbar on the table and the spinner was cut off.

Current behavior: The table is the correct height to show the spinner entirely without a vertical scrollbar.