### PR TITLE
Added prop to use/not use the default url styling and made the additionalUrlParams override the page filters when they include the same parameter

### DIFF
--- a/library/components/TUrl.vue
+++ b/library/components/TUrl.vue
@@ -1,5 +1,5 @@
 <template>
-  <a :href="fullUrl" class="tUrl" :target="openInNewTab ? '_blank' : '_top'" rel="noopener noreferrer">
+  <a :href="fullUrl" :class="{ 'tUrl': includeUrlStyle }" :target="openInNewTab ? '_blank' : '_top'" rel="noopener noreferrer">
     <slot></slot>
   </a>
 </template>
@@ -25,18 +25,29 @@ export default {
     openInNewTab:{
       type: Boolean,
       default: true,
+    },
+    includeUrlStyle: {
+      type: Boolean,
+      default: true
     }
   },
   computed: {
     fullUrl() {
-      let allUrlParams = this.additionalUrlParams;
+      let allUrlParams = {...this.additionalUrlParams};
 
       if (this.includeFilterParams ) {
         const { 'context[org]': org, 'context[group]': group, ...restOfFilters } = this.getFiltersState;
 
+        // Sometimes the additional URL params will include the same filter as one of the filters already in the URL
+        // So the order of the url params below is important, any duplicated keys will end up being the last one added. 
+        // 
+        // example: in the executive summary page there is a filter for project name but in a table each row
+        // is for a project, so when the user clicks a link in that row to go to the issues-detail page, the
+        // url should go to the page with the issues-details filtered on the row's project, not the page where
+        // all of the projects selected in the filter are present.
         allUrlParams = {
-          ...allUrlParams,
-          ...restOfFilters
+          ...restOfFilters,
+          ...allUrlParams
         };
       }
 


### PR DESCRIPTION
To test: 

1. check out the "TURL_testing" branch of snyk-insights
2. click the "Build and Sync modules" icon (cloud between the + and refresh icons)
3. Open: http://localhost:2525/executive_summary?ignored=False&project_name=19377273%257C23023122%257C19174048
4.  Verify that the table at the bottom has 3 rows in the "juice-shop" row, click on the "Open Issues" column.
5.  Verify that the URL in the newly opened tab has the parameter "project_name=19377273", without any additional project ID's
6. Also verify that the styling of the cells in the OPEN ISSUES column is not blue and does not have an underline.
