### PR TITLE
refactor tooltip code

### DIFF
--- a/library/components/TPdf.vue
+++ b/library/components/TPdf.vue
@@ -1,33 +1,30 @@
 <template>
-    <div class="relative" @mouseover="handleTooltip" @mouseleave="showPdfTooltip = false">
+    <div class="relative">
         <!-- PDF tooltip -->
-        <t-tooltip v-if="showPdfTooltip" position="left" width="400px">
+        <t-tooltip position="left" width="400px" is-clickable>
+            <button
+                class="bg-[#145DEB] border-[#145DEB] text-white text-sm px-2 py-[5px] rounded-[4px]"
+                style="height: fit-content;"
+                :disabled="is_loading"
+                @click="downloadPdf"
+                :class="is_loading && 'opacity-60'"
+                slot="trigger"
+            >
+                <div class="flex items-center gap-1">
+                    {{ is_loading ? "Generating PDF" : label }}
+                    <t-loading-spinner
+                        v-if="is_loading"
+                        position="relative"
+                    />
+                </div>
+            </button>
             Your PDF is downloading. It may take up to 30 seconds to complete. Remain on the this page for the download to complete.
         </t-tooltip>
-
-        <button
-            class="bg-[#145DEB] border-[#145DEB] text-white text-sm px-2 py-[5px] rounded-[4px]"
-            style="height: fit-content;"
-            :disabled="is_loading"
-            @click="downloadPdf"
-            :class="is_loading && 'opacity-60'"
-        >
-            <div class="flex items-center gap-1">
-                {{ is_loading ? "Generating PDF" : label }}
-                <t-loading-spinner
-                    v-if="is_loading"
-                    position="relative"
-                />
-            </div>
-        </button>
     </div>
 </template>
 
 <script>
     export default {
-        data: () => ({
-            showPdfTooltip: false,
-        }),
         props: {
             label: {
                 type: String,
@@ -37,14 +34,8 @@
         methods: {
             downloadPdf() {
                 const url = this.page.url + window.location.search;
-                this.showPdfTooltip = true;
                 this.downloadPdfFile(url);
             },
-            handleTooltip() {
-                if (this.is_loading) {
-                    this.showPdfTooltip = true;
-                }
-            }
         }
     } 
 </script>

--- a/library/components/TPdf.vue
+++ b/library/components/TPdf.vue
@@ -18,7 +18,9 @@
                     />
                 </div>
             </button>
-            Your PDF is downloading. It may take up to 30 seconds to complete. Remain on the this page for the download to complete.
+            <div v-if="is_loading">
+                Your PDF is downloading. It may take up to 30 seconds to complete. Remain on the this page for the download to complete.
+            </div>
         </t-tooltip>
     </div>
 </template>

--- a/library/components/TTooltip.vue
+++ b/library/components/TTooltip.vue
@@ -54,7 +54,7 @@ export default {
 			// Calculate and place both tooltip and arrow.
 			const triggerElement = this.$refs.trigger;
 			const tooltipElement = this.$refs.tooltip;
-			const tooltipPositions = {};
+
 			const positions = { arrow: {}, tooltip: {} };
 			if (triggerElement && tooltipElement) {
 				const position = triggerElement.getBoundingClientRect();

--- a/library/components/TTooltip.vue
+++ b/library/components/TTooltip.vue
@@ -41,7 +41,6 @@ export default {
 	data: () => ({
 		positions: {},
 		showTooltip: false,
-		isForcedOpen: false
 	}),
 	mounted() {
 		onClickOutside(this.$refs.tooltipContainer, () => {

--- a/library/components/TTooltip.vue
+++ b/library/components/TTooltip.vue
@@ -1,16 +1,22 @@
 <template>
-	<div @mouseover="handleMouseOver" @click="handleClick" ref="tooltipContainer">
+	<div
+        @mouseover="handleMouseOver"
+        @mouseleave="handleMouseLeave"
+        @click="handleClick"
+        ref="tooltipContainer"
+    >
 		<div ref="trigger">
 			<slot name="trigger">
 				<help-circle-outline-icon :size="12" />
 			</slot>
 		</div>
+
+        <!-- $slots.default is used in cases when the trigger is using v-if on content's div -->
 		<div
 			class="p-4 bg-[#1C1C21] text-white w-max h-max rounded fixed z-50"
 			:style="{ width, ...positions.tooltip }"
 			ref="tooltip"
-			v-show="showTooltip"
-			@mouseleave="handleMouseLeave"
+			v-show="showTooltip && $slots.default"
 		>
 			<slot></slot>
 			<div
@@ -32,19 +38,15 @@ export default {
 			type: String,
 			default: "top"
 		},
-		isClickable: {
-			// Force with prop
-			type: Boolean,
-			default: false
-		}
 	},
 	data: () => ({
 		positions: {},
 		showTooltip: false,
+        isFocused: false,
 	}),
 	mounted() {
 		onClickOutside(this.$refs.tooltipContainer, () => {
-			this.showTooltip = false;
+			this.hide();
 		});
 	},
 	methods: {
@@ -54,58 +56,46 @@ export default {
 			const tooltipElement = this.$refs.tooltip;
 			const tooltipPositions = {};
 			const positions = { arrow: {}, tooltip: {} };
-
 			if (triggerElement && tooltipElement) {
 				const position = triggerElement.getBoundingClientRect();
-
 				if (this.position === "top") {
-
 					positions.tooltip.top = position.top - (tooltipElement.clientHeight + 10) + "px";
 					positions.tooltip.left = position.left - tooltipElement.clientWidth / 2 + "px";
 					positions.arrow.top = position.top - 20 + "px";
 					positions.arrow.left = position.left + "px";
-
 				} else if (this.position === "bottom") {
-
 					positions.tooltip.top = position.top + triggerElement.clientHeight + 15 + "px";
 					positions.tooltip.left = position.left - tooltipElement.clientWidth / 2 + "px";
 					positions.arrow.top = position.top + triggerElement.clientHeight + 10 + "px";
 					positions.arrow.left = position.left + "px";
-
 				} else if (this.position === "left") {
-
 					positions.tooltip.top = position.top - tooltipElement.clientHeight / 2 + "px";
 					positions.tooltip.left = position.left - tooltipElement.clientWidth - 15 + "px";
 					positions.arrow.top = position.top + "px";
 					positions.arrow.left = position.left - 25 + "px";
-
 				} else {
-
 					positions.tooltip.top = position.top - tooltipElement.clientHeight / 2 + "px";
 					positions.tooltip.left = position.left + triggerElement.clientWidth + 15 + "px";
 					positions.arrow.top = position.top + "px";
 					positions.arrow.left = position.left + triggerElement.clientWidth + 10 + "px";
-
 				}
 			}
 			this.positions = positions;
 		},
 		handleMouseOver() {
-			if (this.isClickable) return;
+			if (this.isFocused) return;
 			this.show();
 		},
 		handleMouseLeave() {
-			if (this.isClickable) return;
+			if (this.isFocused) return;
 			this.hide();
 		},
 		handleClick() {
-			if (this.isClickable) {
-				this.show();
-			}
+            this.isFocused = true;
+            this.show();
 		},
 		show() {
 			this.showTooltip = true;
-
 			// Glitchy behaviour without nextTick()
 			this.$nextTick(() => {
 				this.placeTooltip();
@@ -113,6 +103,7 @@ export default {
 		},
 		hide() {
 			this.showTooltip = false;
+            this.isFocused = false;
 		}
 	}
 };

--- a/library/components/TTooltip.vue
+++ b/library/components/TTooltip.vue
@@ -59,35 +59,33 @@ export default {
 				const position = triggerElement.getBoundingClientRect();
 
 				if (this.position === "top") {
-					positions.tooltip.top =
-						position.top - (tooltipElement.clientHeight + 10) + "px";
-					positions.tooltip.left =
-						position.left - tooltipElement.clientWidth / 2 + "px";
+
+					positions.tooltip.top = position.top - (tooltipElement.clientHeight + 10) + "px";
+					positions.tooltip.left = position.left - tooltipElement.clientWidth / 2 + "px";
 					positions.arrow.top = position.top - 20 + "px";
 					positions.arrow.left = position.left + "px";
+
 				} else if (this.position === "bottom") {
-					positions.tooltip.top =
-						position.top + triggerElement.clientHeight + 15 + "px";
-					positions.tooltip.left =
-						position.left - tooltipElement.clientWidth / 2 + "px";
-					positions.arrow.top =
-						position.top + triggerElement.clientHeight + 10 + "px";
+
+					positions.tooltip.top = position.top + triggerElement.clientHeight + 15 + "px";
+					positions.tooltip.left = position.left - tooltipElement.clientWidth / 2 + "px";
+					positions.arrow.top = position.top + triggerElement.clientHeight + 10 + "px";
 					positions.arrow.left = position.left + "px";
+
 				} else if (this.position === "left") {
-					positions.tooltip.top =
-						position.top - tooltipElement.clientHeight / 2 + "px";
-					positions.tooltip.left =
-						position.left - tooltipElement.clientWidth - 15 + "px";
+
+					positions.tooltip.top = position.top - tooltipElement.clientHeight / 2 + "px";
+					positions.tooltip.left = position.left - tooltipElement.clientWidth - 15 + "px";
 					positions.arrow.top = position.top + "px";
 					positions.arrow.left = position.left - 25 + "px";
+
 				} else {
-					positions.tooltip.top =
-						position.top - tooltipElement.clientHeight / 2 + "px";
-					positions.tooltip.left =
-						position.left + triggerElement.clientWidth + 15 + "px";
+
+					positions.tooltip.top = position.top - tooltipElement.clientHeight / 2 + "px";
+					positions.tooltip.left = position.left + triggerElement.clientWidth + 15 + "px";
 					positions.arrow.top = position.top + "px";
-					positions.arrow.left =
-						position.left + triggerElement.clientWidth + 10 + "px";
+					positions.arrow.left = position.left + triggerElement.clientWidth + 10 + "px";
+
 				}
 			}
 			this.positions = positions;

--- a/library/components/TUrlCopyButton.vue
+++ b/library/components/TUrlCopyButton.vue
@@ -1,18 +1,18 @@
 <template>
-    <div class="relative" @mouseover="showTooltip = true" @mouseleave="showTooltip = false">
+    <div class="relative">
         
-        <t-tooltip v-if="showTooltip" position="left" width="max-content">
+        <t-tooltip position="bottom" width="130px">
+            <button
+                class="h-[30px] w-[30px] rounded-[4px] flex items-center justify-center border border-[#C3C2CB] p-1 transition-colors"
+                @click="copy"
+                :class="{ 'bg-[#B4E4D9]': copied }"
+                slot="trigger"
+            >
+                <check-icon :size="18" v-if="copied" />
+                <link-icon :size="18" v-else />
+            </button>
             {{ copied ? "URL Copied" : "Copy URL" }}
         </t-tooltip>
-
-        <button
-            class="h-[30px] w-[30px] rounded-[4px] flex items-center justify-center border border-[#C3C2CB] p-1 transition-colors"
-            @click="copy"
-            :class="{ 'bg-[#B4E4D9]': copied }"
-        >
-            <check-icon :size="18" v-if="copied" />
-            <link-icon :size="18" v-else />
-        </button>
     </div>
 </template>
 
@@ -20,7 +20,6 @@
     export default {
         data: () => ({
             copied: false,
-            showTooltip: false,
         }),
         methods: {
             copy() {

--- a/library/components/TUrlCopyButton.vue
+++ b/library/components/TUrlCopyButton.vue
@@ -10,6 +10,7 @@
             >
                 <check-icon :size="18" v-if="copied" />
                 <link-icon :size="18" v-else />
+                <span class="visually-hidden">{{ copied ? "URL Copied" : "Copy URL" }}</span>
             </button>
             {{ copied ? "URL Copied" : "Copy URL" }}
         </t-tooltip>

--- a/library/components/TUrlCopyButton.vue
+++ b/library/components/TUrlCopyButton.vue
@@ -39,3 +39,19 @@
         }
     }
 </script>
+
+<style>
+/* 
+ * Utility class to hide content visually while keeping it screen reader-accessible.
+ * Source: https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html 
+ */
+    .visually-hidden:not(:focus):not(:active) {
+        clip: rect(0 0 0 0); 
+        clip-path: inset(100%); 
+        height: 1px; 
+        overflow: hidden; 
+        position: absolute; 
+        white-space: nowrap; 
+        width: 1px; 
+    }
+</style>


### PR DESCRIPTION
Fixes:
1. Current tooltip was having trouble placing it self near it's trigger and needed a better approach
2. is-clickable prop can be used to make tooltip appear on click
3. outside click detection function is used to close tooltips
4. t-pdf and t-url-copy-button are now using this new verison as well.

How to test:
1. Switch your config.yml `revision` to this branch.
2. Click Build button inside IDE.
3. Clicking on pdf download will open the new tooltip.
4. Hovering on t-url-copy-button will open the tooltip.

New syntax:

```
<t-tooltip width="200px" position="top" :is-clickable="false">
   <button slot="trigger">button</button>
   This is the tooltip text, now also supports anchor tags.
</t-tooltip>
```