### PR TITLE
Added includeContextParam prop to TURL

### DIFF
--- a/library/components/TUrl.vue
+++ b/library/components/TUrl.vue
@@ -28,16 +28,27 @@ export default {
     },
     includeUrlStyle: {
       type: Boolean,
-      default: true
+      default: true,
+    },
+    includeContextParam:{
+      type: Boolean,
+      default: false
     }
   },
   computed: {
     fullUrl() {
-      let allUrlParams = {...this.additionalUrlParams};
+      let allUrlParams = {};
+      const { 'context[org]': org, 'context[group]': group, ...restOfFilters } = this.getFiltersState;
+
+      if(this.includeContextParam){
+        if(org){
+          allUrlParams['context[org]'] = org
+        }else if(group){
+          allUrlParams['context[group]'] = group
+        }
+      }
 
       if (this.includeFilterParams ) {
-        const { 'context[org]': org, 'context[group]': group, ...restOfFilters } = this.getFiltersState;
-
         // Sometimes the additional URL params will include the same filter as one of the filters already in the URL
         // So the order of the url params below is important, any duplicated keys will end up being the last one added. 
         // 
@@ -46,8 +57,9 @@ export default {
         // url should go to the page with the issues-details filtered on the row's project, not the page where
         // all of the projects selected in the filter are present.
         allUrlParams = {
+          ...allUrlParams,
           ...restOfFilters,
-          ...allUrlParams
+          ...this.additionalUrlParams,
         };
       }
 


### PR DESCRIPTION
To test:

- check out the executive_summary branch of snyk-insights. 
- Open the [executive summary](http://localhost:2525/executive_summary?context%5Borg%5D=4a3d29ab-6612-481b-83f2-aea6cf421ea5&ignored=False&exec_summary_start_date=2022-05-01&exec_summary_end_date=2022-05-31)
- click the "Total Identified" big number
- verify that the url includes the param "context%5Borg%5D=4a3d29ab-6612-481b-83f2-aea6cf421ea5"