### PR TITLE
Added "numberTextColor" to TBigNumber

### DIFF
--- a/visualizations/frontend/other/TBigNumber.vue
+++ b/visualizations/frontend/other/TBigNumber.vue
@@ -16,7 +16,7 @@
         <div :class="hasTallSize ? 'mt-6' : 'mt-3'">
             <span class="font-normal leading-8" :class="fontSizes[bigNumberSize]">
                 <div class="flex items-center gap-2">
-                    <span>{{ value || '--' }}</span>
+                    <span  :style="{ color: numberTextColor }">{{ value || '--' }}</span>
                     {{ valueText }}
                     <div v-if="previous">
                         <span class="opacity-80" v-if="num(value) > num(previous)">
@@ -76,6 +76,10 @@
                 default: '',
             },
             textColor: {
+                type: String,
+                default: '#393842'
+            },
+            numberTextColor: {
                 type: String,
                 default: '#393842'
             },


### PR DESCRIPTION
To test, check out the [executive_summary_blue_clickable_big_numbers](https://github.com/snyk/snyk-insights-topcoat/tree/executive_summary_blue_clickable_big_numbers) branch and open the following page: http://localhost:2525/executive_summary?context%5Borg%5D=4c62f811-1816-4896-a91d-22577bb8eaca&ignored=False&exec_summary_end=2022-08-31&exec_summary_start=2022-04-01

This change is in response to [this slack discussion](https://snyk.slack.com/archives/C03UN2ECN3B/p1661890523584819). 