### PR TITLE
fix: Remove bottom padding from Report component

### DIFF
--- a/library/templates/Report/Report.vue
+++ b/library/templates/Report/Report.vue
@@ -2,7 +2,7 @@
     <div>
         <report-header v-if="hasHeader" />
         <div class="bg-[#F9F9FA]">
-            <div class="flex w-full gap-10 pb-20 content-block">
+            <div class="flex w-full gap-10 content-block">
                 <div class="w-full">
                     <div class="flex flex-wrap justify-between items-center w-full py-4 px-6 border-b border-[#E4E3E8] md:flex-row flex-col gap-1">
                         <slot name="filters"></slot>


### PR DESCRIPTION
Get rid of that bottom padding that is producing a gap at the bottom of the table:
<img width="1534" alt="Screenshot 2022-09-07 at 12 46 44" src="https://user-images.githubusercontent.com/1915140/188861872-e8fe5d66-37aa-4835-8055-82b9be607dc7.png">
