### PR TITLE
Fix/tooltip transition

### DIFF
--- a/library/components/TTooltip.vue
+++ b/library/components/TTooltip.vue
@@ -13,7 +13,7 @@
 		<!-- $slots.default is used in cases when the trigger is using v-if on content's div -->
 		<transition name="fade">
 			<div
-				class="p-4 bg-[#1C1C21] text-white w-max h-max rounded fixed z-50"
+				class="p-2 bg-[#1C1C21] text-white w-max h-max rounded fixed z-50"
 				:style="{ width, ...positions.tooltip }"
 				ref="tooltip"
 				v-show="isVisible && $slots.default"

--- a/library/components/TTooltip.vue
+++ b/library/components/TTooltip.vue
@@ -82,12 +82,6 @@ export default {
 			this.positions = positions;
 		},
 		handleMouseOver() {
-			// Mouseover should also prepare position of tooltip,
-			// Without $nextTick, behaviour is glitched.
-			this.$nextTick(() => {
-				this.placeTooltip();
-			})
-
 			if (this.isOpen) {
 				return;
 			}
@@ -101,6 +95,11 @@ export default {
 		},
 		show() {
 			this.isVisible = true;
+
+			this.$nextTick(() => {
+				// Without $nextTick, behaviour is glitched.
+				this.placeTooltip();
+			})
 		},
 		hide() {
 			this.isVisible = false;

--- a/library/components/TTooltip.vue
+++ b/library/components/TTooltip.vue
@@ -1,121 +1,121 @@
 <template>
-	<div
-		@mouseover="handleMouseOver"
-		@mouseleave="handleMouseLeave"
-		ref="tooltipContainer"
-	>
-		<div ref="trigger">
-			<slot name="trigger">
-				<help-circle-outline-icon :size="12" />
-			</slot>
-		</div>
+  <div
+    @mouseover="handleMouseOver"
+    @mouseleave="handleMouseLeave"
+    ref="tooltipContainer"
+  >
+    <div ref="trigger">
+      <slot name="trigger">
+        <help-circle-outline-icon :size="12" />
+      </slot>
+    </div>
 
-		<!-- $slots.default is used in cases when the trigger is using v-if on content's div -->
-		<transition name="fade">
-			<div
-				class="p-2 bg-[#1C1C21] text-white text-sm w-max h-max rounded fixed z-50"
-				:style="{ width, ...positions.tooltip }"
-				ref="tooltip"
-				v-show="isVisible && $slots.default"
-			>
-				<slot></slot>
-				<div
-					class="bg-[#1C1C21] w-4 h-4 fixed rotate-45"
-					:style="{ ...positions.arrow }"
-				></div>
-			</div>
-		</transition>
-	</div>
+    <!-- $slots.default is used in cases when the trigger is using v-if on content's div -->
+    <transition name="fade">
+      <div
+        class="p-2 bg-[#1C1C21] text-white text-sm w-max h-max rounded fixed z-50"
+        :style="{ width, ...positions.tooltip }"
+        ref="tooltip"
+        v-show="isVisible && $slots.default"
+      >
+        <slot></slot>
+        <div
+          class="bg-[#1C1C21] w-4 h-4 fixed rotate-45"
+          :style="{ ...positions.arrow }"
+        ></div>
+      </div>
+    </transition>
+  </div>
 </template>
 
 <script>
 export default {
-	props: {
-		width: {
-			type: String,
-			default: "200px"
-		},
-		position: {
-			type: String,
-			default: "top"
-		},
-		isOpen: { // To control state from a component.
-			type: Boolean,
-			default: false,
-		}
-	},
-	data: () => ({
-		positions: { arrow: {}, tooltip: {} },
-		isVisible: this.isOpen,
-	}),
-	methods: {
-		placeTooltip() {
-			// Calculate and place both tooltip and arrow.
-			const triggerElement = this.$refs.trigger;
-			const tooltipElement = this.$refs.tooltip;
+  props: {
+    width: {
+      type: String,
+      default: "200px"
+    },
+    position: {
+      type: String,
+      default: "top"
+    },
+    isOpen: { // To control state from a component.
+      type: Boolean,
+      default: false,
+    }
+  },
+  data: () => ({
+    positions: { arrow: {}, tooltip: {} },
+    isVisible: this.isOpen,
+  }),
+  methods: {
+    placeTooltip() {
+      // Calculate and place both tooltip and arrow.
+      const triggerElement = this.$refs.trigger;
+      const tooltipElement = this.$refs.tooltip;
 
-			const positions = { ...this.positions };
-			if (triggerElement && tooltipElement) {
-				const position = triggerElement.getBoundingClientRect();
-				if (this.position === "top") {
-					positions.tooltip.top = position.top - (tooltipElement.clientHeight + 10) + "px";
-					positions.tooltip.left = position.left - tooltipElement.clientWidth / 2 + "px";
-					positions.arrow.top = position.top - 20 + "px";
-					positions.arrow.left = position.left + "px";
-				} else if (this.position === "bottom") {
-					positions.tooltip.top = position.top + triggerElement.clientHeight + 15 + "px";
-					positions.tooltip.left = position.left - tooltipElement.clientWidth / 2 + "px";
-					positions.arrow.top = position.top + triggerElement.clientHeight + 10 + "px";
-					positions.arrow.left = position.left + "px";
-				} else if (this.position === "left") {
-					positions.tooltip.top = position.top - tooltipElement.clientHeight / 2 + "px";
-					positions.tooltip.left = position.left - tooltipElement.clientWidth - 15 + "px";
-					positions.arrow.top = position.top + "px";
-					positions.arrow.left = position.left - 25 + "px";
-				} else {
-					positions.tooltip.top = position.top - tooltipElement.clientHeight / 2 + "px";
-					positions.tooltip.left = position.left + triggerElement.clientWidth + 15 + "px";
-					positions.arrow.top = position.top + "px";
-					positions.arrow.left = position.left + triggerElement.clientWidth + 10 + "px";
-				}
-			}
-			this.positions = positions;
-		},
-		handleMouseOver() {
-			if (this.isOpen) {
-				return;
-			}
-			this.show();
-		},
-		handleMouseLeave() {
-			if (this.isOpen) {
-				return;
-			}
-			this.hide();
-		},
-		show() {
-			this.isVisible = true;
+      const positions = { ...this.positions };
+      if (triggerElement && tooltipElement) {
+        const position = triggerElement.getBoundingClientRect();
+        if (this.position === "top") {
+          positions.tooltip.top = position.top - (tooltipElement.clientHeight + 10) + "px";
+          positions.tooltip.left = position.left - tooltipElement.clientWidth / 2 + "px";
+          positions.arrow.top = position.top - 20 + "px";
+          positions.arrow.left = position.left + "px";
+        } else if (this.position === "bottom") {
+          positions.tooltip.top = position.top + triggerElement.clientHeight + 15 + "px";
+          positions.tooltip.left = position.left - tooltipElement.clientWidth / 2 + "px";
+          positions.arrow.top = position.top + triggerElement.clientHeight + 10 + "px";
+          positions.arrow.left = position.left + "px";
+        } else if (this.position === "left") {
+          positions.tooltip.top = position.top - tooltipElement.clientHeight / 2 + "px";
+          positions.tooltip.left = position.left - tooltipElement.clientWidth - 15 + "px";
+          positions.arrow.top = position.top + "px";
+          positions.arrow.left = position.left - 25 + "px";
+        } else {
+          positions.tooltip.top = position.top - tooltipElement.clientHeight / 2 + "px";
+          positions.tooltip.left = position.left + triggerElement.clientWidth + 15 + "px";
+          positions.arrow.top = position.top + "px";
+          positions.arrow.left = position.left + triggerElement.clientWidth + 10 + "px";
+        }
+      }
+      this.positions = positions;
+    },
+    handleMouseOver() {
+      if (this.isOpen) {
+        return;
+      }
+      this.show();
+    },
+    handleMouseLeave() {
+      if (this.isOpen) {
+        return;
+      }
+      this.hide();
+    },
+    show() {
+      this.isVisible = true;
 
-			this.$nextTick(() => {
-				// Without $nextTick, behaviour is glitched.
-				this.placeTooltip();
-			})
-		},
-		hide() {
-			this.isVisible = false;
-		}
-	},
+      this.$nextTick(() => {
+        // Without $nextTick, behaviour is glitched.
+        this.placeTooltip();
+      })
+    },
+    hide() {
+      this.isVisible = false;
+    }
+  },
 };
 </script>
 
 <style>
-	.fade-enter-active,
-  	.fade-leave-active {
-		transition: opacity 0.5s ease;
-  	}
+  .fade-enter-active,
+    .fade-leave-active {
+    transition: opacity 0.5s ease;
+    }
   
-  	.fade-enter-from,
-  	.fade-leave-to {
-		opacity: 0;
-  	}
+    .fade-enter-from,
+    .fade-leave-to {
+    opacity: 0;
+    }
 </style>

--- a/library/components/TTooltip.vue
+++ b/library/components/TTooltip.vue
@@ -11,18 +11,20 @@
 		</div>
 
 		<!-- $slots.default is used in cases when the trigger is using v-if on content's div -->
-		<div
-			class="p-4 bg-[#1C1C21] text-white w-max h-max rounded fixed z-50"
-			:style="{ width, ...positions.tooltip }"
-			ref="tooltip"
-			v-show="isVisible && $slots.default"
-		>
-			<slot></slot>
+		<transition name="fade">
 			<div
-				class="bg-[#1C1C21] w-4 h-4 fixed rotate-45"
-				:style="{ ...positions.arrow }"
-			></div>
-		</div>
+				class="p-4 bg-[#1C1C21] text-white w-max h-max rounded fixed z-50"
+				:style="{ width, ...positions.tooltip }"
+				ref="tooltip"
+				v-show="isVisible && $slots.default"
+			>
+				<slot></slot>
+				<div
+					class="bg-[#1C1C21] w-4 h-4 fixed rotate-45"
+					:style="{ ...positions.arrow }"
+				></div>
+			</div>
+		</transition>
 	</div>
 </template>
 
@@ -43,7 +45,7 @@ export default {
 		}
 	},
 	data: () => ({
-		positions: {},
+		positions: { arrow: {}, tooltip: {} },
 		isVisible: this.isOpen,
 	}),
 	methods: {
@@ -52,7 +54,7 @@ export default {
 			const triggerElement = this.$refs.trigger;
 			const tooltipElement = this.$refs.tooltip;
 
-			const positions = { arrow: {}, tooltip: {} };
+			const positions = { ...this.positions };
 			if (triggerElement && tooltipElement) {
 				const position = triggerElement.getBoundingClientRect();
 				if (this.position === "top") {
@@ -106,3 +108,15 @@ export default {
 	},
 };
 </script>
+
+<style>
+	.fade-enter-active,
+  	.fade-leave-active {
+		transition: opacity 0.5s ease;
+  	}
+  
+  	.fade-enter-from,
+  	.fade-leave-to {
+		opacity: 0;
+  	}
+</style>

--- a/library/components/TTooltip.vue
+++ b/library/components/TTooltip.vue
@@ -13,7 +13,7 @@
 		<!-- $slots.default is used in cases when the trigger is using v-if on content's div -->
 		<transition name="fade">
 			<div
-				class="p-2 bg-[#1C1C21] text-white w-max h-max rounded fixed z-50"
+				class="p-2 bg-[#1C1C21] text-white text-sm w-max h-max rounded fixed z-50"
 				:style="{ width, ...positions.tooltip }"
 				ref="tooltip"
 				v-show="isVisible && $slots.default"


### PR DESCRIPTION
**Problem:**
1. When tooltip opens, it sometimes have a broken layout for half a second, until it corrects itself.
2. Transition of tooltip open and close is very static.

**Solution**
1. Prevent tooltip from resetting it's position state on each mouse hover and trigger placement logic AFTER it appears.
2. Add fade transition using vue's `<transition />` tag.

**How to test**
1. Switch to this branch inside IDE.
2. Open executive or issues page, click on pdf download or hover on url copy button.

**Expected results**
1. No broken flash when it opens.
2. Subtle fade animation on open and close.