### PR TITLE
Server sort

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -1,22 +1,21 @@
 <template>
   <div class="rootTableContainer">
     <slot name="columnConfig" :setColumnConfig="setColumnConfig"></slot>
-
       <!-- Title -->
       <div class="tableHeaderContainer">
         <div class="title">
-            <span v-if="title">{{ title }}</span>
+            <span v-if="title">{{ title }} </span>
         </div>
 
         <div class="tableControls" v-show="!isPdf">
           <!-- <div>Future Group By</div> -->
-          <t-select-columns
+          <test-select-columns
             v-if="modifiableColumns"
             :modifiableColumns="modifiableColumns"
             @updateFilteredColumns="updateFilteredColumns"
             :t-layer="layer"
           />
-          <TCsvExport
+          <t-csv-export
             v-if="enableCsvDownload"
             :t-layer="layer"
             :additionalFilters="additionalFilters"
@@ -53,6 +52,7 @@
         type="checkbox"
         :indeterminate.prop="someChecked"
       />
+
       <!-- Headings -->
       <div
         v-for="(column, index) in internalColumns"
@@ -61,25 +61,23 @@
         class="headerCell"
         :class="generateHeaderClasses(column.property, index)"
       >
-        <slot :name="generateSlotName('header', column.header)" v-bind="column">
-          {{ column.header }}
-        </slot>
+        <div style="display: flex;align-items: center;">
+          <slot :name="generateSlotName('header', column.header)" v-bind="column">
+            {{ column.header }} 
+          </slot>
 
-        <span
-          v-if="column.sort || column.initialSort"
-          @click="reverseSort(column.property)"
-        >
-          <slot
-            v-if="arrowDirection[column.property] === 'asc'"
-            name="sortAscendingIcon"
-            v-bind="column"
-          >
-            <div class="icon move_up">&#8964;</div>
-          </slot>
-          <slot v-else name="sortDescendingIcon" v-bind="column">
-            <div class="icon move_down">&#8963;</div>
-          </slot>
-        </span>
+          <div v-if="column.sort" @click="updateSort(column)">
+            <slot v-if="column.sort.direction === 'ASC'" name="sortAscendingIcon" v-bind="column">
+              <chevron-up-icon />
+            </slot>
+            <slot v-else-if="column.sort.direction === 'DESC'" name="sortDescendingIcon" v-bind="column">
+              <chevron-down-icon />
+            </slot>
+            <slot v-else name="sortUnsortedIcon" v-bind="column">
+              <unfold-more-horizontal-icon />
+            </slot>
+          </div>
+        </div>
       </div>
 
       <!-- No table data -->
@@ -272,7 +270,7 @@ export default {
     },
     sortDirection: {
       type: String,
-      default: "asc",
+      default: "ASC",
     },
     enableSearchFilter: {
       type: Boolean,
@@ -306,8 +304,18 @@ export default {
       type: Boolean,
       default: true,
     },
+    // TODO: how should this interact with sorting? Should a column that has sorting applied but is hidden have that sorting removed?
     modifiableColumns: {
       type: Array,
+    },
+    sortableColumns:{
+      type: Array,
+      default: () => [],
+    },
+    // TODO: should canPageServer and canSortServer be merged? It doesn't make much sense to have 1 without the other
+    canSortServer:{
+      type: Boolean,
+      default: false,
     },
   },
   emits: {
@@ -318,8 +326,6 @@ export default {
   },
   data() {
     return {
-      columnSortDirection: [],
-      arrowDirection: {},
       internalSelectedItem: null,
       internalSelectedItems: [],
       internalGroups: [],
@@ -438,10 +444,26 @@ export default {
     this.fetchTotalRows();
   },
   methods: {
-        // internal columns takes any column configurations from the TColumnConfig
+	getUrlSortConfiguration(){
+		let urlFilter = this.getFilterState(`${this.layer}_sort`);
+			console.log('urlFilter', urlFilter)
+		const useUrlParams = typeof urlFilter === 'string';
+		if(useUrlParams){
+			const urlSortableColumns =[]
+			const urlFilterArray = urlFilter.split(' ').filter((s) => s!== '')
+			console.log('urlFilterArray', urlFilterArray)
+			for (let i = 0; i < urlFilterArray.length; i+=2) {
+				urlSortableColumns.push({column: urlFilterArray[i], direction: urlFilterArray[i+1].replaceAll(',', '')})
+			}
+			console.log('urlSortableColumns', urlSortableColumns)
+			return urlSortableColumns;
+		}
+		return null;
+	},
+    // internal columns takes any column configurations from the TColumnConfig
     // component and creates default column configurations based on the fields
     // of the first row of data. That way users don't have to manually specify
-    // all of the columns- it is assmumed that if the layer is providing a column
+    // all of the columns- it is assumed that if the layer is providing a column
     // then the data should be shown. So if the first row object is {foo: 2, bar: 2222}
     // and there is a column config for a calculated column {header: 'baz', property:'baz'}
     // the final columns will end up being:
@@ -451,7 +473,7 @@ export default {
     //   {header: 'baz', property:'baz'}
     // ]
     //  plus configurations for sorting etc.
-    setInternalColumns() {
+    setInternalColumns(setColumnSort=true) {
       if (!this.rows || this.rows.length === 0) return [];
       let cols = Object.keys(this.rows[0]);
 
@@ -493,25 +515,77 @@ export default {
         });
       }
 
-      if (this.canSort) {
-        // Note: the "+" in "+col.sort.priority" converts strings to numbers
-        const sortPriorities = cols
-          .map((col) => (col.sort ? +col.sort.priority : null))
-          .filter((priority) => priority !== null)
-          .sort();
+	// All computed columns cannot currently be sorted and will be removed from the sorting configuration
+	//
+	// Some columns can be configured to be sortable with the sortableColumns prop
+	// All columns will be configured to be sortable if the canSort prop is true
+	// if both sortableColumns and canSort are set, sortableColumns is used
+	//
+	// If the url includes sortable column configuration, use that to determine direction and ignore
+	// the default directions in sortableColumns/null direction for canSort
+	// Any columns in the url sortable configuration that are not in sortableColumns should be ignored
+	// when configuring the sorting 
+      if(setColumnSort){
+		const urlSortConfig = this.getUrlSortConfiguration()
+		// Some columns can be sorted
+        if(this.sortableColumns){
+		  let sortableColumns = [...this.sortableColumns]
+		  // sort this.sortableColumns by order of URL column configs if urlSortConfig is set
+		  if(urlSortConfig){
+			  let sortConfig = []
+			  urlSortConfig.forEach((usc) =>{
+				  sortConfig.push(usc)
+				  sortableColumns = sortableColumns.filter((sc) => sc.column !== usc.column)
+			  })
+			  // remove the default sort direction of columns not sorted by the url
+			  sortableColumns.forEach((sc) => delete sc.direction)
+			  // append remaining sortable but not sorted columns to the configuration
+			  sortConfig = sortConfig.concat(sortableColumns)
+			  sortableColumns = sortConfig
+		  }
+          // Note: the _.reverse here is because when sorting on the front end, lodash uses
+          // a stable sort. The increasing order of priority preserves user's previouse sorts.
+          // Here the code needs to emulate that first priority sort being the "latest" column
+          // that is sorted by, same with second etc. So to make the priorities match, the
+          // sortable columns need to be reversed so the first column ends up with the largest
+          // sort priority. 
+          _.reverse(sortableColumns).forEach((sortableColumn,index) =>{
+            const column = cols.find((c) => sortableColumn.column === c.property)
+			console.log('column', column)
+            if(column){
+                column.sort={
+                  priority: index,
+				  direction: sortableColumn.direction
+                };
+            }else{
+                console.warn('Invalid sortable column:', sortableColumn.column)
+            }
+          })
+        }
+        // all columns can be sorted
+        else if (this.canSort) {
+            // Note: the "+" in "+col.sort.priority" converts strings to numbers
+            const sortPriorities = cols
+            .map((col) => (col.sort ? +col.sort.priority : null))
+            .filter((priority) => priority !== null)
+            .sort();
 
-        let maxSortPriority =
-          sortPriorities.length > 0 ? sortPriorities.pop() : 0;
+            let maxSortPriority =
+            sortPriorities.length > 0 ? sortPriorities.pop() : 0;
 
-        cols.forEach((col) => {
-          if (!col.sort) {
-            maxSortPriority += 1;
-            col.sort = {
-              direction: this.sortDirection,
-              priority: maxSortPriority,
-            };
-          }
-        });
+            cols.forEach((col) => {
+				if (!col.sort) {
+					maxSortPriority += 1;
+					col.sort = {
+						direction: this.sortDirection,
+						priority: maxSortPriority,
+					};
+				}
+            });
+        }
+		// if(this.canSortServer){
+		// 	this.setOrderBy();
+		// }
       }
 
       // remove sorting on calculated columns for now.
@@ -577,29 +651,6 @@ export default {
       if (!this.rows) return;
 
       this.setInternalColumns();
-
-      // Handle sorting setup
-      let sortableColumns = this.internalColumns.filter((c) => {
-        return (
-          c.sort && typeof c.sort.priority === "number" && c.sort.direction
-        );
-      });
-
-      if (sortableColumns.length > 0) {
-        sortableColumns = _.sortBy(sortableColumns, ["sort.priority"]);
-        sortableColumns = _.reverse(sortableColumns);
-        sortableColumns.forEach((sortableColumn) => {
-          this.columnSortDirection.push({
-            property: sortableColumn.property,
-            direction: sortableColumn.sort.direction,
-            format: sortableColumn.format,
-            sortBy: sortableColumn.sortBy,
-          });
-          this.arrowDirection[sortableColumn.property] =
-            sortableColumn.sort.direction;
-        });
-      }
-
       this.setupInternalRows();
 
       // Handle radio buttons setup
@@ -742,19 +793,24 @@ export default {
       if (!this.canPageServer) this.totalRows = rows.length;
       return rows;
     },
+    getSortedColumns(){
+      let sortedColumns = this.internalColumns.filter((c)=> c.sort && c.sort.direction)
+      return _.sortBy(sortedColumns, [function(c) { return c.sort.priority; }]);
+    },
     sortRows(rows) {
-      if (this.columnSortDirection.length > 0) {
+      sortedColumns = this.getSortedColumns();
+      if (!this.canSortServer && sortedColumns.length > 0) {
         let sortedRows = [];
         this.internalGroups.forEach((group) => {
           let rowsInGroup = rows.slice(
             group.filteredStartIndex,
             group.filteredEndIndex
           );
-          this.columnSortDirection.forEach((sortableColumn) => {
+          sortedColumns.forEach((sortableColumn) => {
             rowsInGroup = _.sortBy(rowsInGroup, [
               (row) => {
-                if (sortableColumn.sortBy) {
-                  return sortableColumn.sortBy(
+                if (sortableColumn.sort.sortBy) {
+                  return sortableColumn.sort.sortBy(
                     row.originalRow[sortableColumn.property],
                     row.originalRow
                   );
@@ -762,8 +818,9 @@ export default {
                 return this.getCellValue(row, sortableColumn);
               },
             ]);
-            if (sortableColumn.direction === "desc")
+            if (sortableColumn.sort.direction === "DESC"){
               rowsInGroup = _.reverse(rowsInGroup);
+            }
           });
           sortedRows = sortedRows.concat(rowsInGroup);
         });
@@ -783,26 +840,53 @@ export default {
         .filter((cell) => !_.isNil(cell))
         .join(" ");
     },
-    reverseSort(columnProperty) {
-      const sortObject = this.getSortByProperty(columnProperty);
-      _.pull(this.columnSortDirection, [sortObject]);
+    updateSort(column) {
+      const sortPriorities = this.internalColumns.filter((c) => c.sort).map((c)=>c.sort.priority);
+      const maxSortPriority = sortPriorities.reduce((previousValue, currentValue) => {
+        return previousValue > currentValue ? previousValue : currentValue
+      });
+      column.sort.priority = maxSortPriority + 1;
 
-      if (sortObject.direction === "asc") {
-        this.arrowDirection[columnProperty] = "desc";
-        sortObject.direction = "desc";
-      } else {
-        this.arrowDirection[columnProperty] = "asc";
-        sortObject.direction = "asc";
+      if (column.sort.direction === "ASC") {
+        column.sort.direction = "DESC";
+      } else if (column.sort.direction === "DESC") {
+        column.sort.direction = null;
+      }  else {
+        column.sort.direction = "ASC";
       }
 
-      this.columnSortDirection.push(sortObject);
-      this.setupInternalRows();
+      if(this.canSortServer){
+        this.setOrderBy();
+        this.fetchPagedLayer(false);
+      }else{
+        this.setupInternalRows();
+      }
     },
-    getSortByProperty(columnProperty) {
-      return this.columnSortDirection.find(
-        (csd) => csd.property === columnProperty
-      );
+    setOrderBy(){
+        let sortedColumns = _.reverse(this.getSortedColumns());
+        let orderByFilter= sortedColumns.map((sc) => {
+            return ` ${sc.property} ${sc.sort.direction}, `
+        }).reduce((previous, current) => {
+            return previous + current;
+        }, '');
+        // remove trailing comma
+        if(orderByFilter.length > 1){
+            orderByFilter = orderByFilter.slice(0, -2);
+        }
+  this.setOrderByFilter(orderByFilter)
     },
+  setOrderByFilter(orderByFilter){
+    const sortFilterName = `${this.layer}_sort`
+
+    if(!this.metadata.filters.output.find((f)=>f.name === sortFilterName)){
+        this.metadata.filters.output.push({name: sortFilterName, urlparam: sortFilterName})
+    }
+        this.setFilterValue(sortFilterName, orderByFilter);
+
+        const thisTable = this.$store.state.layers.components[this.tag_unique];
+        const tableFilters = thisTable.filters ? thisTable.filters : {}
+    Vue.set(tableFilters, 'orderBy', orderByFilter)
+  },
     showGroupHeader(group) {
       const anyRowsInRange =
         this.indexInPagedRows(group.filteredStartIndex) ||
@@ -977,47 +1061,6 @@ export default {
           "The search input is visible but both the enableSearchFilter and the enableSearchHighlight props are disabled so searching will have no effect"
         );
       }
-
-      // sorting
-      let sortableColumns = this.internalColumns.filter((c) => {
-        return c.sort;
-      });
-      if (sortableColumns.length > 0) {
-        sortableColumns = _.sortBy(sortableColumns, ["sort.priority"]);
-        let lastSortableColumn = null;
-        sortableColumns.forEach((column) => {
-          const sortOptions = column.sort;
-
-          if (typeof sortOptions.priority !== "number") {
-            console.warn(
-              "The sort priority option must be a number. For column " +
-                column.property +
-                " it is a " +
-                typeof sortOptions.priority
-            );
-          }
-          if (!["asc", "desc"].includes(sortOptions.direction)) {
-            console.warn(
-              "The sort direction option must be either 'asc' or 'desc'. For column " +
-                column.property +
-                " it is " +
-                sortOptions.direction
-            );
-          }
-          if (
-            lastSortableColumn !== null &&
-            lastSortableColumn.sort.priority === column.sort.priority
-          ) {
-            console.warn(
-              "The sort priority option for column " +
-                column.property +
-                " is the same as the sort priority option for " +
-                lastSortableColumn.property
-            );
-          }
-          lastSortableColumn = column;
-        });
-      }
     },
     expandRow(row) {
       if (this.onlyShowOneDetailRow) {
@@ -1054,6 +1097,8 @@ export default {
         }
         thisTable.filters.limit = "" + this.rowsPerPage;
         thisTable.filters.offset = "" + this.startIndex;
+
+        console.log('thisTable.filters', thisTable.filters)
         this.fetchPagedLayer();
         return;
       } else {
@@ -1072,15 +1117,16 @@ export default {
           this.totalRows = totalRows;
         });
     },
-    fetchPagedLayer() {
+    fetchPagedLayer(setColumnSort=true) {
       if(!this.allInitializationComplete) return;
       const payload = this.createRequestPayload();
       this.showSpinner = true;
+      console.log('payload',payload)
       this.$store.dispatch("layers/fetchPagedLayer", payload).then(() => {
         if (!this.isDataAvailable) {
           this.init();
         }else{
-          this.setInternalColumns();
+          this.setInternalColumns(setColumnSort);
           this.setupInternalRows();
         }
       });

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -9,13 +9,13 @@
 
         <div class="tableControls" v-show="!isPdf">
           <!-- <div>Future Group By</div> -->
-          <test-select-columns
+          <t-select-columns
             v-if="modifiableColumns"
             :modifiableColumns="modifiableColumns"
             @updateFilteredColumns="updateFilteredColumns"
             :t-layer="layer"
           />
-          <test-csv-export
+          <t-csv-export
             v-if="enableCsvDownload"
             :t-layer="layer"
             :additionalFilters="additionalFilters"

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -15,7 +15,7 @@
             @updateFilteredColumns="updateFilteredColumns"
             :t-layer="layer"
           />
-          <t-csv-export
+          <test-csv-export
             v-if="enableCsvDownload"
             :t-layer="layer"
             :additionalFilters="additionalFilters"
@@ -871,11 +871,12 @@ export default {
             orderByFilter = orderByFilter.slice(0, -2);
         }
   		const sortFilterName = `${this.layer}_sort`
-		if(!this.metadata.filters.output.find((f)=>f.name === sortFilterName)){
-			this.metadata.filters.output.push({name: sortFilterName, urlparam: sortFilterName})
-		}
-		this.setFilterValue(sortFilterName, orderByFilter);
-		this.setTableFilter('orderBy', orderByFilter)
+      if(!this.metadata.filters.output.find((f)=>f.name === sortFilterName)){
+        this.metadata.filters.output.push({name: sortFilterName, urlparam: sortFilterName})
+      }
+      this.setFilterValue(sortFilterName, orderByFilter);
+      this.setTableFilter('orderBy', orderByFilter)
+      Vue.set(this.additionalFilters, 'orderBy', orderByFilter)
     },
     showGroupHeader(group) {
       const anyRowsInRange =
@@ -1172,7 +1173,8 @@ export default {
         console.error('Modify Column Configuration includes "undefined" value, please check that all layer column names are quoted!')
       }
       const columnList = JSON.stringify(allValidColumns)
-      this.additionalFilters = allValidColumns.length > 0 ? { column_list: columnList } : {}
+      Vue.set(this.additionalFilters, 'column_list', allValidColumns.length > 0 ? columnList  : null)
+
       const tableFilters = thisTable.filters ? {...thisTable.filters} : {}
       tableFilters.column_list = columnList;
       this.storeAttribute({


### PR DESCRIPTION
Goal: provide server-side sorting that is done in the sql to the table.

To test:
1. In  snyk-insights, check out the "server_sort" branch and run "build and sync modules"
2. Open snyk-insights in the [iFrame](https://app.snyk.io/group/5ea22317-e879-4eb9-8ef7-411dc7c3a604/reporting?context%5Bpage%5D=issues-detail&issue_status=Open&issue_by=Severity)
3. Verify that the table starts sorted by "SCORE" descending, "ISSUE" ascending, and that the "PRODUCT" column is sortable but not currently sorted.
4. Click the up/down/up-down icons to sort by columns
5. Open the URL in a new tab and verify that the updated sorting is preserved- not just which columns are sorted, but also the order in which they are sorted
6. Export a pdf and verify that the sorted table in the pdf matches the page
7. Export csv and verify that the rows are sorted in the same way as the table.

Known issues: 
The table has grown into a cluster, I'm aware that the sorting data is stored in 4 places which is _ridiculous_. But the correct fix for that is a complete refactor of the table to split the layer handling into a wrapper and turn the table back into a "dumb" non-topcoat component, plus a refactor of the export to csv component- both of which are far outside the scope of this PR. I will tackle those refactors ASAP, so if you see anything here please feel free to call it out- I will make a note of it even if it falls outside of the scope of this sorting PR.
