### PR TITLE
remove underline from links

### DIFF
--- a/library/components/TUrl.vue
+++ b/library/components/TUrl.vue
@@ -78,6 +78,5 @@ export default {
 <style scoped>
 .tUrl {
   color: rgba(20, 93, 235);
-  text-decoration: underline;
 }
 </style>


### PR DESCRIPTION
Goal: remove the underlines from links, per conversation with @gau94rav 

To test: in snyk-insights check out the "remove_link_underline" branch and sync modules, then open the issue details page and verify that all the links are no longer underlined.