### PR TITLE
Fix modify columns

### DIFF
--- a/visualizations/frontend/other/TSelectColumns.vue
+++ b/visualizations/frontend/other/TSelectColumns.vue
@@ -109,6 +109,9 @@ export default {
     TLayer: {
       type: String,
     },
+    urlFilter: {
+      type: String,
+    }
   },
   data: () => ({
     checked: [],
@@ -116,26 +119,20 @@ export default {
     isExpanded: false,
     internalColumns: [],
   }),
-  mounted() {
-    let urlFilter = this.getFilterState(this.urlParamName);
-    const useUrlParams = typeof urlFilter === 'string';
-    if (urlFilter) {
-      urlFilter = urlFilter.split("|");
-    }
-
-    this.modifiableColumns.forEach((col) => {
-      const label = col.displayColumn;
-      const iCol = { label: label, sqlColumns: col.layerColumns };
-      this.internalColumns.push(iCol);
-      if (useUrlParams) {
-        if (urlFilter.includes(label)) this.checked.push(iCol);
-      } else if (col.displayByDefault) {
-        this.checked.push(iCol);
-      }
-    });
-    this.$emit("updateFilteredColumns", this.checked);
-  },
   watch: {
+    urlFilter(){
+      this.modifiableColumns.forEach((col) => {
+        const label = col.displayColumn;
+        const iCol = { label: label, sqlColumns: col.layerColumns };
+        this.internalColumns.push(iCol);
+        if (this.urlFilter && this.urlFilter.length > 0) {
+          if (this.urlFilter.includes(label)) this.checked.push(iCol);
+        } else if (col.displayByDefault) {
+          this.checked.push(iCol);
+        }
+      });
+      this.$emit("updateFilteredColumns", this.checked);
+    },
     checked() {
       this.updateChecked()
     },


### PR DESCRIPTION
Goal:
Allow users to show/hide columns on the fly. This includes updating the columns shown in pdf and csv exports in addition to what appears in the table.

To test:
Note: The ISSUE_SEVERITY and ISSUE columns cannot be hidden and will always be present. Because the ISSUE columns depends on multiple layer columns, all of those layer columns will end up in the csv export.
1. Check out the modify_columns branch in snyk-insights
2. sync modules
3. in the iframe, open the issue details page
4. Verify that the following columns are present: 
- [ ] SCORE
- [ ] ISSUE
- [ ] CVE
- [ ] CWE
- [ ] PROJECT
- [ ] EXPLOIT MATURITY
- [ ] AUTO FIXABLE
- [ ] INTRODUCED
- [ ] PRODUCT
5. Select/Deselect columns
6. Verify that the selected/deselect columns are added/removed from the table as appropriate.
7. Refresh the page
8. Verify that the columns you selected/deselected are still present/absent as appropriate
9. Export a pdf, verify that none of the data is cut off and that the columns you selected/deselected are present/absent as appropriate
10. Export a csv, verify that the columns you selected/deselected are present/absent as appropriate
11. Select All the columns and verify that the table in the pdf does not have a horizontal scroll and cut off part of the data
12. Reset All the columns and verify that pdf and csv generation works