### PR TITLE
Fix reset button in modify columns

### DIFF
--- a/visualizations/frontend/other/TSelectColumns.vue
+++ b/visualizations/frontend/other/TSelectColumns.vue
@@ -53,7 +53,7 @@
           >
             Select All
           </span>
-          <span v-else @click="deselectAll"> Reset </span>
+          <span v-else @click="reset"> Reset </span>
         </span>
       </div>
       <div class="px-[8px] pt-[4px] pb-[6px] w-full">
@@ -147,8 +147,17 @@ export default {
       this.checked = [...this.internalColumns];
       const visibleColumnlabels = this.checked.map((c) => c.label);
     },
-    deselectAll() {
-      this.checked = [];
+    reset() {
+      this.checked = []
+      this.modifiableColumns.forEach((col) => {
+        const label = col.displayColumn;
+        const iCol = { label: label, sqlColumns: col.layerColumns };
+        this.internalColumns.push(iCol);
+        if (col.displayByDefault) {
+          this.checked.push(iCol);
+        }
+      });
+      this.$emit("updateFilteredColumns", this.checked);
     },
     updateChecked: _.debounce(function(){
       this.$emit("updateFilteredColumns", this.checked);


### PR DESCRIPTION
Goal: Make the "reset" button in modify columns reset to the default visible columns, not just the columns that cannot be hidden.

To test:
1. Check out the "modify_columns_updates" branch in snyk-insights
2. syn modules
3. open issue details page
4. select and deselect columns
5. in modify columns, click the "Select All"
6. in modify columns, click "reset"
7. verify that the following columns are visible after the reset:
SCORE
ISSUE
CVE
CWE
PROJECT
EXPLOIT MATURITY
AUTO FIXABLE
INTRODUCED
PRODUCT

Notes: It would be much better to remove the filter entirely, unfortunately due to the limitation where visualizations cannot be nested TSelectColumns does not have access to the functions that handle that and this is simpler than adding a reset event or reinventing the wheel.