### PR TITLE
chore: add gray background to rows that can expand

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -1074,6 +1074,7 @@ export default {
       classes += _.camelCase(column.property);
       classes += cindex % 2 === 0 ? " evenColumn" : " oddColumn";
       classes += rindex % 2 === 0 ? " evenRow" : " oddRow";
+      classes += this.canCollapseDetailRows ? " bg-[#F9F8FA]" : ""
       classes += " " + this.cellClasses;
       return classes;
     },

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -136,16 +136,24 @@
             :key="rindex + row.toString()"
             class="makeGridIgnoreDiv row"
           >
-            <!-- Expand/Collapse controls for the details row -->
-            <button v-if="canCollapseDetailRows" @click="toggleRow(row)">
+          <!-- Expand/Collapse controls for the details row -->
+          <div
+            v-if="canCollapseDetailRows"
+            class="bg-[#F9F8FA] border-b border-[#d3d3d9] pt-[12px]"
+          >
+            <button
+              @click="toggleRow(row)"
+              class="focus:outline-none focus-visible:ring"
+            >
               <span aria-hidden="true">
-                <chevron-down-icon v-if="row.detailRowOpen"  />
+                <chevron-down-icon v-if="row.detailRowOpen" />
                 <chevron-right-icon v-else />
               </span>
               <span class="sr-only">
                 {{ row.detailRowOpen ? "collapse row" : "open row" }}
               </span>
             </button>
+          </div>
 
             <!-- Radio buttons -->
             <input


### PR DESCRIPTION
This PR adds a background color to rows on a table with the `canCollapseDetailRows` prop set. It also makes a few updates to the toggle to bring it close to the design, and also add a background colour to it.


### Before
![Screen Shot 2022-09-28 at 17 53 14-fullpage](https://user-images.githubusercontent.com/1307818/192826922-198c171f-1ce8-4ab8-a58b-87f65a163a8f.png)


### After
![Screen Shot 2022-09-28 at 17 53 54-fullpage](https://user-images.githubusercontent.com/1307818/192827057-1396de34-0d64-495c-803a-5629bf93d1af.png)


### If you want to test
The grouped table is being used in the Vulnerability Report
Go to 
* Switch the Git branch in https://snyk-insights.topcoatdata.app/a/develop to point to `feat/vulnerability` 
* change the https://snyk-insights.topcoatdata.app/a/develop/project/config|yml to point to `chore/update-collapsible-row-color` for topcoat-public

```
modules:
    - git: https://github.com/topcoat-data/topcoat-public.git
      revision: chore/update-collapsible-row-color
```

* rebuild modules, by clicking the cloud icon.
* Go to https://snyk-insights.topcoatdata.app/vuln-detail
* You should see the grouped table there.


## Screenshot of Design 
![Issue Table Grouped](https://user-images.githubusercontent.com/1307818/192594918-cf2a6edf-b342-4316-ac25-c9c74ce828db.png)

Link to Design Files: https://www.figma.com/file/IaywW74sLSgYJSYHjOC0ZL/Reporting-Beta-2022?node-id=3485%3A62854