### PR TITLE
Added excludeFromSort table prop

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -335,6 +335,10 @@ export default {
         return [null, 'ASC', 'DESC'].includes(value)
       }
     },
+    excludeFromSort: {
+      type: Array,
+      default: () => [],
+    },
   },
   emits: {
     "update:selectedItem": null,
@@ -560,6 +564,13 @@ export default {
           sortConfig = sortConfig.concat(sortableColumns)
           sortableColumns = sortConfig
         }
+
+        this.excludeFromSort.forEach((efs) => {
+          let cleanSortableColumns = _.remove(sortableColumns, (sc) => {
+            return !efs.includes(sc.column);
+          });
+          sortableColumns = cleanSortableColumns
+        })
         // Note: the _.reverse here is because when sorting on the front end, lodash uses
         // a stable sort. The increasing order of priority preserves user's previouse sorts.
         // Here the code needs to emulate that first priority sort being the "latest" column


### PR DESCRIPTION
Goal: Allow users to exclude a column from sorting.

To test:

1. In snyk-insights, check out the implement_sort branch
2. sync modules
3. open the Issues Detail page
4. Verify that the first column with the severity icon and no header is not sortable.