### PR TITLE
RFC: rejig how spacing is created between TTable sections

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="rootTableContainer">
     <slot name="columnConfig" :setColumnConfig="setColumnConfig"></slot>
+    <div class="rootTableContainer">
 
       <!-- Title -->
       <div class="tableHeaderContainer">
-        <div class="title">
-            <div v-if="title">{{ title }}</div>
+        <div>
+            <p class="title" v-if="title">{{ title }}</p>
             <t-tooltip v-if="tooltip" position="top" class="tooltip" width="260px">
               <help-circle-outline-icon slot="trigger" :size="16" />
               <div class="text-sm leading-[18px] font-normal">
@@ -1232,7 +1232,9 @@ export default {
 }
 
 .rootTableContainer {
-  display: inline-block;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
   width: 100%;
   height: 100%;
   max-width: inherit;
@@ -1275,7 +1277,6 @@ export default {
 
 #tableContainer {
   display: grid;
-  margin: 5px;
   position: relative;
 }
 
@@ -1329,11 +1330,7 @@ highlighting a row on hover etc. */
   font-weight: 400;
   font-size: 20px;
   line-height: 23px;
-  display: flex;
-  align-items: center;
   font-feature-settings: "tnum" on, "lnum" on;
-  padding-top: 15px;
-  padding-bottom: 15px;
 }
 
 .tooltip{
@@ -1345,17 +1342,18 @@ highlighting a row on hover etc. */
 
 .tableHeaderContainer {
   display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   justify-content: space-between;
   width: 100%;
   overflow: visible;
+  gap: 15px;
 }
 .tableControls {
   display: flex;
   gap: 10px;
   align-items: center;
+  justify-content: flex-end;
 }
 
-.csvExportButton{
-  min-width: 130px;
-}
 </style>

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -206,7 +206,7 @@
       </div>
     </div>
 
-    <div v-if="!isPdf" style="margin: 0px auto">
+    <div v-if="!isPdf">
       <SnykPager
         v-if="canPage || canPageServer"
         id="pagingControls"


### PR DESCRIPTION
This is a proposal to rejig how we space items in the table, particularly the header. We had to come up with a big long conditional to hide a piece of the UI in this PR: https://github.com/topcoat-data/topcoat-public/pull/156/files#diff-7e4511d830c406b3a4cb3b11b35473535e081cec4d6280eef0e1c7c991f4a474R6

Given that Vue doesn't render components with `v-if`, if we add `gap` on a flex container, it will space its flex items nicely. It means we don't need to rely on the spacing on an individual item to create the spacing needed, so if it isn't rendered the spacing will be predictable.

This isn't a comprehensive refactoring of the spacing and is only intended to enable the aforementioned PR to avoid a big conditional. However, if we like this approach we could look for more applications in the table. 

## Before Changes
relying on title padding
table margin pushes it away from edge - things don't look aligned

<img width="1460" alt="Screenshot 2022-09-29 at 14 11 47" src="https://user-images.githubusercontent.com/1307818/193028138-f97a927a-632a-4864-9e16-a19e7ea475c9.png">
<img width="1447" alt="Screenshot 2022-09-29 at 14 12 16" src="https://user-images.githubusercontent.com/1307818/193028140-b53ef0a7-b95a-4e52-aa68-3d47e5cf91f0.png">

<img width="1448" alt="Screenshot 2022-09-29 at 14 11 30" src="https://user-images.githubusercontent.com/1307818/193028131-9bd141b0-3040-4859-b84d-c37ad79036d2.png">

<img width="1445" alt="Screenshot 2022-09-29 at 14 11 12" src="https://user-images.githubusercontent.com/1307818/193028118-3453f6e2-5d6d-47b4-abd3-9014474b95a0.png">


## After changes
turn on your dev tools and explore the layout tools to see the flex grids (let me know if you need me to show you).
<img width="1444" alt="Screenshot 2022-09-29 at 14 16 13" src="https://user-images.githubusercontent.com/1307818/193028901-39270f1d-05f2-4a2e-8107-f16ae958d467.png">
<img width="1448" alt="Screenshot 2022-09-29 at 14 14 44" src="https://user-images.githubusercontent.com/1307818/193028966-7342f715-e9ae-4379-9d4c-9b26ae4f3d1d.png">
<img width="1453" alt="Screenshot 2022-09-29 at 14 15 15" src="https://user-images.githubusercontent.com/1307818/193028970-8669cb2c-aada-4d29-bc80-a2e52ad418bf.png">
<img width="1452" alt="Screenshot 2022-09-29 at 14 15 42" src="https://user-images.githubusercontent.com/1307818/193028972-12f593ce-a003-4b75-bd4d-35662a411eb5.png">
<img width="1434" alt="Screenshot 2022-09-29 at 14 15 59" src="https://user-images.githubusercontent.com/1307818/193028980-ba9cc9c8-08af-4de3-af94-21ae7715ef1e.png">

![Screen Shot 2022-09-29 at 14 44 50-fullpage](https://user-images.githubusercontent.com/1307818/193034724-7aa026a0-6264-49eb-a556-76fe9788a2b2.png)


