### PR TITLE
isRequired prop added for date picker

### DIFF
--- a/visualizations/frontend/filters/v2/TDatePicker.vue
+++ b/visualizations/frontend/filters/v2/TDatePicker.vue
@@ -22,7 +22,7 @@
         <div class="flex items-center gap-1">
           <calendar-blank-outline-icon class="text-[16px]" />
           {{ relativePreset.label }}
-          <button @click="handleClear">
+          <button @click="handleClear" v-if="!isRequired">
             <close-icon title="clear date selection" />
           </button>
           <menu-down-icon class="text-[20px]" />
@@ -48,7 +48,7 @@
       <div slot="icon-calendar" v-if="!relativePreset">
         <div class="flex items-center gap-1">
           <t-loading-spinner position="relative" v-if="loading" />
-          <button @click="handleClear">
+          <button @click="handleClear" v-if="!isRequired">
             <close-icon />
           </button>
           <calendar-blank-outline-icon />
@@ -88,6 +88,10 @@ export default {
     defaultDatePreset: {
       type: String,
       default: "",
+    },
+    isRequired: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {


### PR DESCRIPTION
`is-required` prop can be used to hide clear dates button, to make sure there is always a default value selected.