### PR TITLE
Table design fixes

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -92,7 +92,7 @@
               <chevron-down-icon />
             </slot>
             <slot v-else name="sortUnsortedIcon" v-bind="column">
-              <unfold-more-horizontal-icon />
+              <unfold-more-horizontal-icon  class="unsortedIcon" />
             </slot>
           </div>
         </div>
@@ -1252,7 +1252,10 @@ export default {
 
 <style scoped>
 .sortIcon{
-  color: #55546375
+  color: #323232;
+}
+.unsortedIcon{
+  opacity: 0.5;
 }
 .tableDataContainer{
   max-width: 100%;

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -76,7 +76,7 @@
         v-for="(column, index) in internalColumns"
         :key="column.header"
         :ref="'headerCell_' + index"
-        class="headerCell"
+        class="headerCell text-[12px]"
         :class="generateHeaderClasses(column.property, index)"
       >
         <div style="display: flex;align-items: center;">

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -76,7 +76,7 @@
         v-for="(column, index) in internalColumns"
         :key="column.header"
         :ref="'headerCell_' + index"
-        class="headerCell text-[12px]"
+        class="headerCell"
         :class="generateHeaderClasses(column.property, index)"
       >
         <div style="display: flex;align-items: center;">
@@ -311,7 +311,7 @@ export default {
     headerClasses: {
       type: String,
       default:
-        "py-2 border-b border-[#D3D3D9] text-[10px] text-[#555463] font-semibold leading-[15px] tracking-[0.12em] uppercase",
+        "py-2 border-b border-[#D3D3D9] text-[12px] text-[#555463] font-semibold leading-[15px] tracking-[0.12em] uppercase",
     },
     cellClasses: {
       type: String,

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -86,13 +86,13 @@
 
           <div v-if="column.sort" @click="updateSort(column)" class="sortIcon">
             <slot v-if="column.sort.direction === 'ASC'" name="sortAscendingIcon" v-bind="column">
-              <chevron-up-icon />
+              <chevron-up-icon :size="20" />
             </slot>
             <slot v-else-if="column.sort.direction === 'DESC'" name="sortDescendingIcon" v-bind="column">
-              <chevron-down-icon />
+              <chevron-down-icon :size="20" />
             </slot>
             <slot v-else name="sortUnsortedIcon" v-bind="column">
-              <unfold-more-horizontal-icon  class="unsortedIcon" />
+              <unfold-more-horizontal-icon  class="unsortedIcon" :size="20"/>
             </slot>
           </div>
         </div>

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -84,7 +84,7 @@
             {{ column.header }} 
           </slot>
 
-          <div v-if="column.sort" @click="updateSort(column)">
+          <div v-if="column.sort" @click="updateSort(column)" class="sortIcon">
             <slot v-if="column.sort.direction === 'ASC'" name="sortAscendingIcon" v-bind="column">
               <chevron-up-icon />
             </slot>
@@ -1251,6 +1251,9 @@ export default {
 </script>
 
 <style scoped>
+.sortIcon{
+  color: #55546375
+}
 .tableDataContainer{
   max-width: 100%;
   overflow-x: scroll;

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -86,13 +86,13 @@
 
           <div v-if="column.sort" @click="updateSort(column)" class="sortIcon">
             <slot v-if="column.sort.direction === 'ASC'" name="sortAscendingIcon" v-bind="column">
-              <chevron-up-icon :size="20" />
+              <menu-up-icon :size="20" />
             </slot>
             <slot v-else-if="column.sort.direction === 'DESC'" name="sortDescendingIcon" v-bind="column">
-              <chevron-down-icon :size="20" />
+              <menu-down-icon :size="20" />
             </slot>
             <slot v-else name="sortUnsortedIcon" v-bind="column">
-              <unfold-more-horizontal-icon  class="unsortedIcon" :size="20"/>
+              <menu-swap-icon :size="20" class="unsortedIcon" />
             </slot>
           </div>
         </div>


### PR DESCRIPTION
Quick updates to the header cell font size, sorting icon colors, and update sorting icons to triangles instead of chevrons. To test, update the modules branch to table_design_fixes, the headers should have a 12px font size, the sorting icons should be #323232, and the unsorted icon should have opacity .5. 