### PR TITLE
Don't reset pager if it doesn't exist

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -707,7 +707,8 @@ export default {
     onVisualizationUpdated() {
       this.updateEndIndex(this.rowsPerPage);
       this.updateStartIndex(0);
-      this.pagerResetFunction();
+      if (this.pagerResetFunction)
+        this.pagerResetFunction();
       this.fetchTotalRows();
     },
     init() {


### PR DESCRIPTION
I don't think this is hugely significant, but this error show up in the console when rendering the pdf template, for example
https://dave.topcoatdev.net/reporting/issues-detail/pdf?issue_status=Open


```
TypeError: this.pagerResetFunction is not a function
    at o.onVisualizationUpdated (pdf?issue_status=Open&issue_by=Severity&table_issues_detail_cols=SCORE%7CCVE%7CCWE%7CPROJECT%7CEXPLOIT+MATURITY%7CAUTO+FIXABLE%7CINTRODUCED%7CSNYK+PRODUCT:1927:12)
    at o.loading (core.4c21d8d71bc715e36d64.js:2:3463150)
    at qe (core.4c21d8d71bc715e36d64.js:2:2943436)
    at xn.run (core.4c21d8d71bc715e36d64.js:2:2959950)
    at bn (core.4c21d8d71bc715e36d64.js:2:2957921)
    at Array.<anonymous> (core.4c21d8d71bc715e36d64.js:2:2944522)
    at et (core.4c21d8d71bc715e36d64.js:2:2943921)
```