### PR TITLE
TUrl encoding fix

### DIFF
--- a/library/components/TUrl.vue
+++ b/library/components/TUrl.vue
@@ -72,7 +72,11 @@ export default {
         };
       }
 
-      const urlParamString = new URLSearchParams(allUrlParams).toString();
+      // const urlParamString = new URLSearchParams(allUrlParams).toString();
+      const urlParamString = Object.entries(allUrlParams)
+        .map(([key, val]) => {
+          return `${key}=${val}`;
+        }).join("&")
 
       if (urlParamString.length > 0) {
         return `${this.url}?${urlParamString}`;


### PR DESCRIPTION
[JIRA](https://snyksec.atlassian.net/browse/DP-503?focusedCommentId=580269&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-580269)

**Problem**
Drill down urls were not being decoded by filters

**Cause**
URLSearchParams was adding additional encoding to all the params which results in broken values, after a recent change to `page.js` in topcoat-core.

**Fix**
The double encoding was removed and a simple loop and concat logic was used for url params string.