### PR TITLE
add default filter slot to filter section

### DIFF
--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -9,6 +9,7 @@
           :is="tag"
           :ref="tag"
         >
+          <slot name="defaultFilter"></slot>
           <div
             v-if="!data.isDefault"
             class="flex items-center justify-end cursor-pointer"

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -3,13 +3,13 @@
     <filter-variant-icon class="relative top-[5px]" :size="18" />
     <div class="flex flex-col items-start justify-start gap-2">
       <div class="flex flex-wrap items-center gap-1">
+        <slot name="defaultFilter"></slot>
         <component
           v-for="(data, tag) in visibleFilters"
           :key="tag"
           :is="tag"
           :ref="tag"
         >
-          <slot name="defaultFilter"></slot>
           <div
             v-if="!data.isDefault"
             class="flex items-center justify-end cursor-pointer"


### PR DESCRIPTION
**What's added**
A default filter slot for filter section.

**Reason**
A default filter does not have to go through the initialisation process as it is always visible, adding any filter to this slot will remove it from dropdown's init logic.

**Usage**
```
<t-filters-section>
    <t-select slot="defaultFilter" />
    // This filter will be removed from dropdown's init logic and will be directly displayed on page.
</t-filters-section>
```