### PR TITLE
Fix/t url encoding

### DIFF
--- a/library/components/TUrl.vue
+++ b/library/components/TUrl.vue
@@ -39,6 +39,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    isDoubleEncoded: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     fullUrl() {
@@ -72,9 +76,16 @@ export default {
         };
       }
 
-      const urlParamString = new URLSearchParams(allUrlParams)
-        .toString()
-        .replace(/\+/g, "%2520");
+      let urlParamString = new URLSearchParams(allUrlParams).toString();
+
+      if (this.isDoubleEncoded) {
+        const params = new URLSearchParams();
+        for (let key in allUrlParams) {
+          params.set(key, encodeURIComponent(allUrlParams[key]));
+        }
+
+        urlParamString = params.toString();
+      }
 
       if (urlParamString.length > 0) {
         return `${this.url}?${urlParamString}`;

--- a/library/components/TUrl.vue
+++ b/library/components/TUrl.vue
@@ -75,7 +75,11 @@ export default {
       // const urlParamString = new URLSearchParams(allUrlParams).toString();
       const urlParamString = Object.entries(allUrlParams)
         .map(([key, val]) => {
-          return `${key}=${val}`;
+          if (typeof val === "object") {
+            return `${key}=${encodeURIComponent(JSON.stringify(val))}`;
+          } else {
+            return `${key}=${encodeURIComponent(val)}`;
+          }
         }).join("&")
 
       if (urlParamString.length > 0) {

--- a/library/components/TUrl.vue
+++ b/library/components/TUrl.vue
@@ -72,7 +72,11 @@ export default {
         };
       }
 
-      const urlParamString = new URLSearchParams(allUrlParams).toString();
+      // const urlParamString = new URLSearchParams(allUrlParams).toString();
+      const urlParamString = Object.entries(allUrlParams)
+        .map(([key, val]) => {
+          return `${key}=${val}`;
+        }).join("&")
 
       if (urlParamString.length > 0) {
         return `${this.url}?${urlParamString}`;

--- a/library/components/TUrl.vue
+++ b/library/components/TUrl.vue
@@ -72,15 +72,9 @@ export default {
         };
       }
 
-      // const urlParamString = new URLSearchParams(allUrlParams).toString();
-      const urlParamString = Object.entries(allUrlParams)
-        .map(([key, val]) => {
-          if (typeof val === "object") {
-            return `${key}=${encodeURIComponent(JSON.stringify(val))}`;
-          } else {
-            return `${key}=${encodeURIComponent(val)}`;
-          }
-        }).join("&")
+      const urlParamString = new URLSearchParams(allUrlParams)
+        .toString()
+        .replace(/\+/g, "%2520");
 
       if (urlParamString.length > 0) {
         return `${this.url}?${urlParamString}`;


### PR DESCRIPTION
**Problem**
new URLSearchParams cannot handle space properly, it replaces it with `+`

**Fix**
Generate URL with double encoding like registry.


Note: This will be a temporary fix.