### PR TITLE
Fix/selector race condition

### DIFF
--- a/visualizations/frontend/filters/v2/TMultiSelector.vue
+++ b/visualizations/frontend/filters/v2/TMultiSelector.vue
@@ -261,7 +261,7 @@ export default {
         this.setFilterValue("selected_items", this.defaultValue);
       }
     },
-    selectUnselect() {
+    selectUnselect: _.debounce(function () {
       if (this.checked.length === this.menu.length) {
         this.checked = [];
       } else {
@@ -269,7 +269,7 @@ export default {
         this.checked = this.menu.map((i) => i.value);
       }
       this.updateUrlParam();
-    },
+    }, 750),
     updateUrlParam(value) {
       if (value) {
         this.checked = [...value];


### PR DESCRIPTION
This addresses [Jira ticket 480](https://snyksec.atlassian.net/browse/DP-480) where the data in the big numbers did not match the selected filters until the page was refreshed. If you watch the video linked in the ticket starting at right at 37 minutes in you can see that the issue happens when Ezra deselects the "open" status, the layers start to refresh, and he then selects the "ignored" status before the layers have finished updating. So a classic race condition . It was a bit challenging to reproduce, but clicking different statuses quickly in repeated succession does the trick eventually. 


To test, update the config.yml to point to `revision: fix/selector_race_condition` and build and sync modules. Now when updating the status, or any other multi-select filter, there is a very slight delay (750 milliseconds, same as the delay in the modify columns) before the new selection(s) update the filter which should prevent layers from getting out of sync.