### PR TITLE
add visible item count and limit for multi and tags selectors

### DIFF
--- a/visualizations/frontend/filters/TTagsSelector.vue
+++ b/visualizations/frontend/filters/TTagsSelector.vue
@@ -15,7 +15,7 @@
         <div v-if="selected.length" class="flex flex-wrap gap-1">
           <span>:</span>
           <div
-            v-for="selectedTag of selected"
+            v-for="selectedTag of selected.slice(0, selectedVisibleCount)"
             :key="selectedTag"
             class="bg-[#EAF1FF] rounded flex items-center gap-1 rounded"
           >
@@ -31,8 +31,17 @@
           </div>
         </div>
       </div>
-      <t-loading-spinner v-if="loading" position="relative" />
-      <menu-down-icon v-else :size="20" />
+      <div class="flex items-center tracking-widest">
+        <div
+          v-if="selected.length > selectedVisibleCount"
+          class="flex items-center gap-2"
+        >
+          <div class="border-r border-[#7FA7F5] py-2"></div>
+          +{{ selected.length - selectedVisibleCount }}
+        </div>
+        <t-loading-spinner v-if="loading" position="relative" />
+        <menu-down-icon v-else :size="20" />
+      </div>
     </div>
 
     <!-- Popup Contents -->
@@ -170,6 +179,10 @@ export default {
     valueLimit: {
       type: Number,
       default: 30,
+    },
+    selectedVisibleCount: {
+      type: Number,
+      default: 5,
     },
   },
   data: () => ({

--- a/visualizations/frontend/filters/v2/TMultiSelector.vue
+++ b/visualizations/frontend/filters/v2/TMultiSelector.vue
@@ -23,7 +23,7 @@
           <div v-if="canShowSelected" class="flex items-center font-normal">
             :
             <div
-              v-for="(item, index) in checked"
+              v-for="(item, index) in checked.slice(0, selectedVisibleCount)"
               :key="item"
               class="flex items-center pl-1"
             >
@@ -32,6 +32,13 @@
                 <close-icon :size="14" @click.stop="removeItem(item)" />
               </span>
               <span v-else-if="checked.length - 1 != index">, </span>
+            </div>
+            <div
+              v-if="checked.length > selectedVisibleCount"
+              class="flex items-center gap-2 font-medium pl-1"
+            >
+              <div class="border-r border-[#7FA7F5] py-2"></div>
+              +{{ checked.length - selectedVisibleCount }}
             </div>
           </div>
           <div v-else>
@@ -193,6 +200,10 @@ export default {
     canShowSelected: {
       type: Boolean,
       default: false,
+    },
+    selectedVisibleCount: {
+      type: Number,
+      default: 5,
     },
   },
   data: () => ({


### PR DESCRIPTION
**Problem**
Currently a filter with many selected values can go out of div bouns.

**Solution**
Added a new prop called `selectedVisibleCount` that shows 5 items by default and can be customized.

[Figma](https://www.figma.com/file/1Yt1eSMomCATi3wBUeG5tr/Patch-ProductUI?node-id=10233%3A123753&t=hwTO67gRaXSBqvUZ-4)