### PR TITLE
Add delete icon to filters, fix hover border color

### DIFF
--- a/library/components/TDropdown.vue
+++ b/library/components/TDropdown.vue
@@ -142,6 +142,6 @@ export default {
 }
 
 .dropdown-filter .in-active {
-  @apply border-[#C3C2CB] text-[#555463] bg-white;
+  @apply border-[#C3C2CB] hover:border-[#555463] text-[#555463] bg-white;
 }
 </style>

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -11,12 +11,29 @@
           :ref="tag"
         >
           <div class="flex items-center justify-end cursor-pointer">
-            <div
-              class="w-[34px] h-[32px] border border-[#B3B2BD] rounded flex items-center justify-center"
-              @click="removeFilter(data.filters)"
-            >
-              X
-            </div>
+            <t-tooltip position="right" width="100px">
+              <div
+                slot="trigger"
+                class="w-[34px] h-[32px] border border-[#B3B2BD] hover:border-[#555463] rounded flex items-center justify-center"
+                @click="removeFilter(data.filters)"
+              >
+                <!-- Limitation: Using icon component as <delete-icon /> does not work with $slots manipulation -->
+                <!-- Svg of icon is used directly -->
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10.6667 6V12.6667H5.33337V6H10.6667ZM9.66671 2H6.33337L5.66671 2.66667H3.33337V4H12.6667V2.66667H10.3334L9.66671 2ZM12 4.66667H4.00004V12.6667C4.00004 13.4 4.60004 14 5.33337 14H10.6667C11.4 14 12 13.4 12 12.6667V4.66667Z"
+                    fill="#555463"
+                  />
+                </svg>
+              </div>
+              Remove filter
+            </t-tooltip>
           </div>
         </component>
         <t-filters-dropdown :items="menuItems" @opened="handleFilterOpen" />


### PR DESCRIPTION
This PR adds following changes.

1. Show delete icon inside filters.
2. Fix hover color for add filter button.

Note: Due to programmatic slot manipulation with filter section, using a third party icon directly does not work at this point, so direct SVG code is being used.

[Figma](https://www.figma.com/file/IaywW74sLSgYJSYHjOC0ZL/Reporting-Beta-2022?node-id=5133%3A84594&t=nHWDZSuSjPJ5Juu3-4)