### PR TITLE
Feat/add remove all filters

### DIFF
--- a/library/components/TCsvExport.vue
+++ b/library/components/TCsvExport.vue
@@ -41,10 +41,9 @@ export default {
       };
       let filters = this.getFiltersState() ? this.getFiltersState() : [];
 
-      let formattedFilters = {};
-      filters.forEach(
-        (filter) => (formattedFilters[filter.name] = filter.value)
-      );
+  const formattedFilters = filters.reduce((acc, filter) => {
+    return {...acc, [filter.name]: filter.value}
+  }, {});
 
       if (this.additionalFilters) {
         filters = { ...formattedFilters, ...this.additionalFilters };

--- a/library/components/TCsvExport.vue
+++ b/library/components/TCsvExport.vue
@@ -36,13 +36,18 @@ export default {
   methods: {
     download() {
       this.is_loading = true;
-      payload = {
+      const payload = {
         layer: this.tLayer,
       };
-      let filters = this.getFiltersState ? this.getFiltersState : {};
+      let filters = this.getFiltersState() ? this.getFiltersState() : [];
+
+      let formattedFilters = {};
+      filters.forEach(
+        (filter) => (formattedFilters[filter.name] = filter.value)
+      );
 
       if (this.additionalFilters) {
-        filters = { ...filters, ...this.additionalFilters };
+        filters = { ...formattedFilters, ...this.additionalFilters };
       }
 
       this.trackExport("csv");

--- a/library/components/TCsvExport.vue
+++ b/library/components/TCsvExport.vue
@@ -41,9 +41,9 @@ export default {
       };
       let filters = this.getFiltersState() ? this.getFiltersState() : [];
 
-  const formattedFilters = filters.reduce((acc, filter) => {
-    return {...acc, [filter.name]: filter.value}
-  }, {});
+      const formattedFilters = filters.reduce((acc, filter) => {
+        return { ...acc, [filter.name]: filter.value };
+      }, {});
 
       if (this.additionalFilters) {
         filters = { ...formattedFilters, ...this.additionalFilters };

--- a/library/components/TFilterGroup.vue
+++ b/library/components/TFilterGroup.vue
@@ -175,9 +175,15 @@ export default {
           const metadata = componentInstance.metadata;
           const filters =
             metadata && metadata.filters ? metadata.filters.output : [];
+          console.log("handleActiveFilters filters", filters);
 
           for (let filter of filters) {
             const value = this.getFiltersState[filter.urlparam];
+            console.log(
+              "handleActiveFilters value",
+              value,
+              this.getFiltersState
+            );
 
             if (value) {
               const obj = setFilters[componentInstance.tag_unique];

--- a/library/components/TFilterGroup.vue
+++ b/library/components/TFilterGroup.vue
@@ -175,15 +175,8 @@ export default {
           const metadata = componentInstance.metadata;
           const filters =
             metadata && metadata.filters ? metadata.filters.output : [];
-          console.log("handleActiveFilters filters", filters);
-
           for (let filter of filters) {
             const value = this.getFiltersState[filter.urlparam];
-            console.log(
-              "handleActiveFilters value",
-              value,
-              this.getFiltersState
-            );
 
             if (value) {
               const obj = setFilters[componentInstance.tag_unique];

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -110,8 +110,8 @@ export default {
       // To preserve original add order for filter
       // this loop is required again.
       let assignedFilters = [];
-      for (let filterIndex in this.selectedFilters) {
-        const filterName = this.selectedFilters[filterIndex].name;
+      for (const filter of this.selectedFilters) {
+        const filterName = filter.name;
         if (assignedFilters.includes(filterName)) {
           continue;
         }
@@ -167,7 +167,8 @@ export default {
           if (
             unusedOnly &&
             this.selectedFilters.find(
-              (selectedFilter) => selectedFilter.name.toLowerCase() === param.toLowerCase()
+              (selectedFilter) =>
+                selectedFilter.name.toLowerCase() === param.toLowerCase()
             )
           ) {
             urlFilters = [];

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -180,7 +180,7 @@ export default {
       }
       return urlFilters;
     },
-    removeFilter(urlFilters, vfname) {
+    removeFilter(urlFilters, visibleFilterName) {
       for (let filterName of urlFilters) {
         const filterIndex = this.selectedFilters.findIndex(
           (f) => f.name === filterName
@@ -191,7 +191,7 @@ export default {
         this.deleteFilter({ name: filterName });
         this.filters = this.filters.filter((sf) => sf.name !== filterName);
       }
-      this.$delete(this.visibleFilters, vfname);
+      this.$delete(this.visibleFilters, visibleFilterName);
       this.handleMenuItems();
     },
     resetAllFilters() {

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -38,10 +38,12 @@
         </component>
         <t-filters-dropdown :items="menuItems" @opened="handleFilterOpen" />
 
-
-        <div class="flex gap-1 text-[#145DEB] cursor-pointer" @click="resetAllFilters">
-            <backup-restore-icon :size="18" />
-            Reset all filters
+        <div
+          class="flex gap-1 text-[#145DEB] cursor-pointer"
+          @click="resetAllFilters"
+        >
+          <backup-restore-icon :size="18" />
+          Reset all filters
         </div>
       </div>
     </div>
@@ -183,11 +185,11 @@ export default {
       }
       this.handleItems();
     },
-    resetAllFilters(){
-        Object.keys(this.visibleFilters).forEach((vfname)=>{
-            this.removeFilter(this.visibleFilters[vfname].filters)
-        })
-        this.resetAllFilters
+    resetAllFilters() {
+      Object.keys(this.visibleFilters).forEach((vfname) => {
+        this.removeFilter(this.visibleFilters[vfname].filters);
+      });
+      this.resetAllFilters;
     },
     addDeleteButton(tag) {
       this.$nextTick(() => {

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -167,7 +167,7 @@ export default {
           if (
             unusedOnly &&
             this.selectedFilters.find(
-              (sf) => sf.name.toLowerCase() === param.toLowerCase()
+              (selectedFilter) => selectedFilter.name.toLowerCase() === param.toLowerCase()
             )
           ) {
             urlFilters = [];

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -182,12 +182,12 @@ export default {
     },
     removeFilter(urlFilters, visibleFilterName) {
       for (let filterName of urlFilters) {
-        const filterIndex = this.selectedFilters.findIndex(
-          (f) => f.name === filterName
-        );
-        if (filterIndex > -1) {
-          this.selectedFilters.splice(filterIndex, 1);
-        }
+        // const filterIndex = this.selectedFilters.findIndex(
+        //   (f) => f.name === filterName
+        // );
+        // if (filterIndex > -1) {
+        //   this.selectedFilters.splice(filterIndex, 1);
+        // }
         this.deleteFilter({ name: filterName });
       }
       this.$delete(this.visibleFilters, visibleFilterName);

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -39,7 +39,7 @@
         <t-filters-dropdown :items="menuItems" @opened="handleFilterOpen" />
 
 
-        <div class="flex gap-1 hover:text-[#145DEB] cursor-pointer" @click="removeAllFilters">
+        <div class="flex gap-1 text-[#145DEB] cursor-pointer" @click="removeAllFilters">
             <backup-restore-icon :size="18" />
             Reset all filters
         </div>

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -173,7 +173,6 @@ export default {
       return urlFilters;
     },
     removeFilter(urlFilters) {
-        console.log('removeFilter', urlFilters)
       for (let filter of urlFilters) {
         this.deleteFilter({ name: filter });
         if (
@@ -185,7 +184,6 @@ export default {
       this.handleItems();
     },
     removeAllFilters(){
-        console.log('this.visibleFilters', this.visibleFilters)
         Object.keys(this.visibleFilters).forEach((vfname)=>{
             this.removeFilter(this.visibleFilters[vfname].filters)
         })

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -160,21 +160,22 @@ export default {
       this.handleItems();
     },
     getFilters(attrs, unusedOnly = false) {
+      console.log("getFilters", attrs, this.selectedFilters);
       let urlFilters = [];
-      for (let attribute of Object.keys(attrs)) {
-        const param = attrs[attribute];
-        if (attribute.includes("t-filter")) {
-          if (
-            Object.prototype.hasOwnProperty.call(this.selectedFilters, param) &&
-            unusedOnly
-          ) {
-            urlFilters = [];
-            break;
-          } else {
-            urlFilters.push(param);
-          }
-        }
-      }
+      //   for (let attribute of Object.keys(attrs)) {
+      //     const param = attrs[attribute];
+      //     if (attribute.includes("t-filter")) {
+      //       if (
+      //         Object.prototype.hasOwnProperty.call(this.selectedFilters, param) &&
+      //         unusedOnly
+      //       ) {
+      //         urlFilters = [];
+      //         break;
+      //       } else {
+      //         urlFilters.push(param);
+      //       }
+      //     }
+      //   }
       return urlFilters;
     },
     removeFilter(urlFilters) {

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -39,7 +39,7 @@
         <t-filters-dropdown :items="menuItems" @opened="handleFilterOpen" />
 
 
-        <div class="flex gap-1 text-[#145DEB] cursor-pointer" @click="removeAllFilters">
+        <div class="flex gap-1 text-[#145DEB] cursor-pointer" @click="resetAllFilters">
             <backup-restore-icon :size="18" />
             Reset all filters
         </div>
@@ -183,10 +183,11 @@ export default {
       }
       this.handleItems();
     },
-    removeAllFilters(){
+    resetAllFilters(){
         Object.keys(this.visibleFilters).forEach((vfname)=>{
             this.removeFilter(this.visibleFilters[vfname].filters)
         })
+        this.resetAllFilters
     },
     addDeleteButton(tag) {
       this.$nextTick(() => {

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -58,7 +58,6 @@ export default {
     menuItems: [],
     visibleFilters: {},
     lastAddedFilter: null,
-    selectedFilters: [],
   }),
   computed: {
     slotItems() {
@@ -69,7 +68,6 @@ export default {
     },
   },
   mounted() {
-    this.selectedFilters = this.filters;
     this.handleItems();
   },
   methods: {
@@ -110,7 +108,7 @@ export default {
       // To preserve original add order for filter
       // this loop is required again.
       let assignedFilters = [];
-      for (const filter of this.selectedFilters) {
+      for (const filter of this.getFiltersState) {
         const filterName = filter.name;
         if (assignedFilters.includes(filterName)) {
           continue;
@@ -150,11 +148,11 @@ export default {
       this.lastAddedFilter = item.tag;
       for (let filterName of item.filters) {
         if (
-          !this.selectedFilters.find((f) => {
+          !this.getFiltersState.find((f) => {
             f.name === filterName;
           })
         ) {
-          this.selectedFilters.push({ name: filterName, value: "" });
+          this.getFiltersState.push({ name: filterName, value: "" });
         }
       }
       this.handleItems();
@@ -166,7 +164,7 @@ export default {
         if (attribute.includes("t-filter")) {
           if (
             unusedOnly &&
-            this.selectedFilters.find(
+            this.getFiltersState.find(
               (selectedFilter) =>
                 selectedFilter.name.toLowerCase() === param.toLowerCase()
             )
@@ -182,12 +180,6 @@ export default {
     },
     removeFilter(urlFilters, visibleFilterName) {
       for (let filterName of urlFilters) {
-        // const filterIndex = this.selectedFilters.findIndex(
-        //   (f) => f.name === filterName
-        // );
-        // if (filterIndex > -1) {
-        //   this.selectedFilters.splice(filterIndex, 1);
-        // }
         this.deleteFilter({ name: filterName });
       }
       this.$delete(this.visibleFilters, visibleFilterName);

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -189,7 +189,6 @@ export default {
           this.selectedFilters.splice(filterIndex, 1);
         }
         this.deleteFilter({ name: filterName });
-        this.filters = this.filters.filter((sf) => sf.name !== filterName);
       }
       this.$delete(this.visibleFilters, visibleFilterName);
       this.handleMenuItems();

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -37,13 +37,13 @@
           </div>
         </component>
         <t-filters-dropdown :items="menuItems" @opened="handleFilterOpen" />
-      </div>
 
-      <!-- Todo: add reset filters functionality -->
-      <!-- <div class="flex gap-1 hover:text-[#145DEB] cursor-pointer">
-        <backup-restore-icon :size="18" />
-        Reset all filters
-      </div> -->
+
+        <div class="flex gap-1 hover:text-[#145DEB] cursor-pointer" @click="removeAllFilters">
+            <backup-restore-icon :size="18" />
+            Reset all filters
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -173,6 +173,7 @@ export default {
       return urlFilters;
     },
     removeFilter(urlFilters) {
+        console.log('removeFilter', urlFilters)
       for (let filter of urlFilters) {
         this.deleteFilter({ name: filter });
         if (
@@ -182,6 +183,12 @@ export default {
         }
       }
       this.handleItems();
+    },
+    removeAllFilters(){
+        console.log('this.visibleFilters', this.visibleFilters)
+        Object.keys(this.visibleFilters).forEach((vfname)=>{
+            this.removeFilter(this.visibleFilters[vfname].filters)
+        })
     },
     addDeleteButton(tag) {
       this.$nextTick(() => {

--- a/library/components/TFiltersSection.vue
+++ b/library/components/TFiltersSection.vue
@@ -64,6 +64,9 @@ export default {
     slotItems() {
       return this.$slots.default || [];
     },
+    defaultFilterSlotItems() {
+      return this.$slots.defaultFilter || [];
+    },
   },
   mounted() {
     this.selectedFilters = this.filters;
@@ -186,6 +189,9 @@ export default {
       this.handleItems();
     },
     resetAllFilters() {
+      this.defaultFilterSlotItems.forEach((dfsi) => {
+        dfsi?.componentInstance?.reset();
+      });
       Object.keys(this.visibleFilters).forEach((vfname) => {
         this.removeFilter(this.visibleFilters[vfname].filters);
       });

--- a/library/components/TUrl.vue
+++ b/library/components/TUrl.vue
@@ -47,11 +47,13 @@ export default {
   computed: {
     fullUrl() {
       let allUrlParams = {};
+      const allFilters = {};
+      this.filters.forEach((f) => (allFilters[f.name] = f.value));
       const {
         "context[org]": org,
         "context[group]": group,
         ...restOfFilters
-      } = this.getFiltersState;
+      } = allFilters;
 
       if (this.includeContextParam) {
         if (org) {

--- a/library/components/TUrl.vue
+++ b/library/components/TUrl.vue
@@ -47,8 +47,9 @@ export default {
   computed: {
     fullUrl() {
       let allUrlParams = {};
-      const allFilters = {};
-      this.filters.forEach((f) => (allFilters[f.name] = f.value));
+      const allFilters = this.getFiltersState.reduce((acc, filter) => {
+        return { ...acc, [filter.name]: filter.value };
+      }, {});
       const {
         "context[org]": org,
         "context[group]": group,

--- a/library/components/TUrlCopyButton.vue
+++ b/library/components/TUrlCopyButton.vue
@@ -28,12 +28,12 @@ export default {
     url() {
       if (this.parentUrl) {
         this.parentUrl.searchParams.set("context[page]", this.page.url);
-        for (const filter of this.filters) {
+        this.filters.map((filter) => {
           this.parentUrl.searchParams.set(
             filter.name,
             encodeURIComponent(filter.value)
           );
-        }
+        });
         return this.parentUrl.toString();
       }
 

--- a/library/components/TUrlCopyButton.vue
+++ b/library/components/TUrlCopyButton.vue
@@ -28,8 +28,11 @@ export default {
     url() {
       if (this.parentUrl) {
         this.parentUrl.searchParams.set("context[page]", this.page.url);
-        for (const [filter, value] of Object.entries(this.filters)) {
-          this.parentUrl.searchParams.set(filter, encodeURIComponent(value));
+        for (const filter of this.filtersNew) {
+          this.parentUrl.searchParams.set(
+            filter.name,
+            encodeURIComponent(filter.value)
+          );
         }
         return this.parentUrl.toString();
       }

--- a/library/components/TUrlCopyButton.vue
+++ b/library/components/TUrlCopyButton.vue
@@ -28,7 +28,7 @@ export default {
     url() {
       if (this.parentUrl) {
         this.parentUrl.searchParams.set("context[page]", this.page.url);
-        for (const filter of this.filtersNew) {
+        for (const filter of this.filters) {
           this.parentUrl.searchParams.set(
             filter.name,
             encodeURIComponent(filter.value)

--- a/visualizations/frontend/filters/TRangeSelector.vue
+++ b/visualizations/frontend/filters/TRangeSelector.vue
@@ -41,17 +41,17 @@
         :step="step"
         :min-value="barMinValue"
         :max-value="barMaxValue"
-        @input="update"
+        @input="handleSlider"
       />
       <div class="flex items-center justify-between px-2">
         <small>Min: {{ minValue }}</small>
         <small>Max: {{ maxValue }}</small>
       </div>
-      <div class="flex items-center justify-between px-2 gap-2 pb-2">
+      <div class="flex items-center justify-between gap-2 px-2 pb-2">
         <t-tooltip position="right" width="155px">
           <div
             slot="trigger"
-            class="border rounded flex justify-between items-center gap-1"
+            class="flex items-center justify-between gap-1 border rounded"
             :class="
               focusedInput === 'min'
                 ? 'border-[#145DEB] text-[#145DEB]'
@@ -78,7 +78,7 @@
         <t-tooltip position="left" width="155px">
           <div
             slot="trigger"
-            class="border rounded flex justify-between items-center gap-1"
+            class="flex items-center justify-between gap-1 border rounded"
             :class="
               focusedInput === 'max'
                 ? 'border-[#145DEB] text-[#145DEB]'
@@ -102,9 +102,9 @@
           <span>Press enter to confirm</span>
         </t-tooltip>
       </div>
-      <div v-if="$slots['footer']" class="p-2 border-t border-[#E4E3E8]">
-        <slot name="footer"></slot>
-      </div>
+    </div>
+    <div v-if="$slots['footer']" class="p-2 border-t border-[#E4E3E8]">
+      <slot name="footer"></slot>
     </div>
   </t-dropdown>
 </template>
@@ -181,11 +181,17 @@ export default {
     this.fetchLayerData();
   },
   methods: {
+    handleSlider(e, type = null) {
+      this.triggerCaption(true);
+      this.update(e, type);
+    },
     update: window._.debounce(function (e, type = null) {
+      this.triggerCaption();
       if (type) {
         this.handleInputs(e.target.value, type);
         return;
       }
+
       this.barMinValue = e.minValue;
       this.barMaxValue = e.maxValue;
     }, 250),
@@ -214,6 +220,12 @@ export default {
         value = this.maxValue;
       }
       this.barMaxValue = value;
+    },
+    triggerCaption(show = false) {
+      const element = document.querySelectorAll(".multi-range-slider .caption");
+      element.forEach((e) => {
+        e.style.display = show ? "flex" : "none";
+      });
     },
   },
 };

--- a/visualizations/frontend/filters/TRangeSelector.vue
+++ b/visualizations/frontend/filters/TRangeSelector.vue
@@ -162,7 +162,7 @@ export default {
         return minInternal ? parseInt(minInternal) : this.minValue;
       },
       set(val) {
-        this.setFilterValue("min", val, true);
+        this.setFilterValue("min", val);
         return val;
       },
     },
@@ -172,7 +172,7 @@ export default {
         return maxInternal ? parseInt(maxInternal) : this.maxValue;
       },
       set(val) {
-        this.setFilterValue("max", val, true);
+        this.setFilterValue("max", val);
         return val;
       },
     },

--- a/visualizations/frontend/filters/TTagsSelector.vue
+++ b/visualizations/frontend/filters/TTagsSelector.vue
@@ -187,6 +187,7 @@ export default {
     defaultValue: {
       type: Array,
       default: () => [],
+    },
     searchFields: {
       type: Array,
       default: null,

--- a/visualizations/frontend/filters/TTagsSelector.vue
+++ b/visualizations/frontend/filters/TTagsSelector.vue
@@ -184,6 +184,10 @@ export default {
       type: Number,
       default: 5,
     },
+    defaultValue: {
+      type: Array,
+      default: () => [],
+    },
   },
   data: () => ({
     selected: [],
@@ -254,8 +258,11 @@ export default {
           console.error(error);
           console.error("Failed to parse tags data");
         }
+      } else if (this.defaultValue) {
+        selected = [...this.defaultValue];
       }
       this.selected = selected;
+      this.updateUrlValue();
     },
     selectValue(value) {
       this.selected.push({
@@ -320,6 +327,10 @@ export default {
         return this.expanded.push(key);
       }
       return (this.expanded = this.expanded.filter((k) => k !== key));
+    },
+    reset() {
+      this.selected = [...this.defaultValue];
+      this.updateUrlValue();
     },
   },
 };

--- a/visualizations/frontend/filters/TTextInput.vue
+++ b/visualizations/frontend/filters/TTextInput.vue
@@ -271,7 +271,7 @@ export default {
       set(value) {
         this.text_internal = value;
         // Todo: Remove this when spa is live
-        this.setFilterValue("query", this.text_internal, true);
+        this.setFilterValue("query", this.text_internal);
         // Todo: Use this when spa is live
         // this.setFilterValue({ filterName: 'query', filterValue: this.text_internal, notify: true })
       },
@@ -300,7 +300,7 @@ export default {
       }
       this.value = this.text_internal;
       // Todo: Remove this when spa is live
-      this.setFilterValue("query", this.text_internal, true);
+      this.setFilterValue("query", this.text_internal);
       // Todo: Use this when spa is live
       // this.setFilterValue({ filterName: 'query', filterValue: this.text_internal, notify: true })
     },

--- a/visualizations/frontend/filters/date_picker.html
+++ b/visualizations/frontend/filters/date_picker.html
@@ -295,17 +295,15 @@
       apply() {
         this.pickerOpened = false;
         if (this.pickerMode == "single") {
-          this.setFilterValue("date", this.date.format("YYYY-MM-DD"), false);
+          this.setFilterValue("date", this.date.format("YYYY-MM-DD"));
         } else {
           this.setFilterValue(
             "start_date",
-            this.startDate.format("YYYY-MM-DD"),
-            false
+            this.startDate.format("YYYY-MM-DD")
           );
           this.setFilterValue(
             "end_date",
-            this.endDate.format("YYYY-MM-DD"),
-            false
+            this.endDate.format("YYYY-MM-DD")
           );
 
           var start = this.startDate.clone();
@@ -346,17 +344,17 @@
             ? this.refEnd.format("YYYY-MM-DD")
             : "";
           if (this.prevMode) {
-            this.setFilterValue("previous_mode", prevMode, false);
+            this.setFilterValue("previous_mode", prevMode);
           }
           if (this.prevStartDate) {
-            this.setFilterValue("prev_start_date", prevStartDate, false);
+            this.setFilterValue("prev_start_date", prevStartDate);
           }
           if (this.prevEndDate) {
-            this.setFilterValue("prev_end_date", prevEndDate, true);
+            this.setFilterValue("prev_end_date", prevEndDate);
           }
         }
         console.log(this.datePreset);
-        this.setFilterValue("date_preset", this.datePreset, false);
+        this.setFilterValue("date_preset", this.datePreset);
       },
       presetChange(event, first) {
         // Remember previous
@@ -453,7 +451,7 @@
         } else {
           if (!date_preset && defaultPreset) {
             this.datePreset = defaultPreset;
-            this.setFilterValue("date_preset", defaultPreset, false);
+            this.setFilterValue("date_preset", defaultPreset);
           }
         }
 
@@ -463,7 +461,7 @@
             this.previousMode = "year";
           else this.previousMode = "period";
           const prevMode = includePrevious ? this.previousMode : "";
-          this.setFilterValue("previous_mode", this.previousMode, false);
+          this.setFilterValue("previous_mode", this.previousMode);
         } else {
           this.previousMode = previous_mode;
         }
@@ -490,23 +488,21 @@
 
           this.setFilterValue(
             "start_date",
-            this.startDate.format("YYYY-MM-DD"),
-            false
+            this.startDate.format("YYYY-MM-DD")
           );
           this.setFilterValue(
             "end_date",
-            this.endDate.format("YYYY-MM-DD"),
-            false
+            this.endDate.format("YYYY-MM-DD")
           );
-          this.setFilterValue("date", this.date.format("YYYY-MM-DD"), false);
+          this.setFilterValue("date", this.date.format("YYYY-MM-DD"));
           const prevStartDate = includePrevious
             ? this.refStart.format("YYYY-MM-DD")
             : "";
           const prevEndDate = includePrevious
             ? this.refEnd.format("YYYY-MM-DD")
             : "";
-          this.setFilterValue("prev_start_date", prevStartDate, false);
-          this.setFilterValue("prev_end_date", prevEndDate, true);
+          this.setFilterValue("prev_start_date", prevStartDate);
+          this.setFilterValue("prev_end_date", prevEndDate);
         }
       },
       openPicker() {

--- a/visualizations/frontend/filters/date_range.html
+++ b/visualizations/frontend/filters/date_range.html
@@ -184,14 +184,14 @@
               return dPreset;
             } else if (!date_preset && this.config.default_preset) {
               this.datePreset = this.config.default_preset;
-              this.setFilterValue("date_preset", this.datePreset, false);
+              this.setFilterValue("date_preset", this.datePreset);
               return this.datePreset;
             }
           }
         },
         set(value) {
           this.datePreset = value[0];
-          this.setFilterValue("date_preset", this.datePreset, false);
+          this.setFilterValue("date_preset", this.datePreset);
         },
       },
       defaultPreset() {
@@ -250,13 +250,11 @@
 
         this.setFilterValue(
           "start_date",
-          this.startDate.format("YYYY-MM-DD"),
-          false
+          this.startDate.format("YYYY-MM-DD")
         );
         this.setFilterValue(
           "end_date",
-          this.endDate.format("YYYY-MM-DD"),
-          false
+          this.endDate.format("YYYY-MM-DD")
         );
 
         var start = this.startDate.clone();
@@ -295,10 +293,10 @@
         const prevEndDate = includePrevious
           ? this.refEnd.format("YYYY-MM-DD")
           : "";
-        this.setFilterValue("previous_mode", prevMode, false);
-        this.setFilterValue("prev_start_date", prevStartDate, false);
-        this.setFilterValue("prev_end_date", prevEndDate, true);
-        this.setFilterValue("date_preset", this.datePreset, false);
+        this.setFilterValue("previous_mode", prevMode);
+        this.setFilterValue("prev_start_date", prevStartDate);
+        this.setFilterValue("prev_end_date", prevEndDate);
+        this.setFilterValue("date_preset", this.datePreset);
       },
       presetChange(event, first) {
         // Remember previous
@@ -374,10 +372,10 @@
         } else {
           if (!this.config.default_preset) {
             this.datePreset = this.defaultPreset;
-            this.setFilterValue("date_preset", this.datePreset, false);
+            this.setFilterValue("date_preset", this.datePreset);
           } else if (!date_preset && this.config.default_preset) {
             this.datePreset = this.config.default_preset;
-            this.setFilterValue("date_preset", this.datePreset, false);
+            this.setFilterValue("date_preset", this.datePreset);
             return this.datePreset;
           }
         }
@@ -388,7 +386,7 @@
             this.previousMode = "year";
           else this.previousMode = "period";
           const prevMode = includePrevious ? this.previousMode : "";
-          this.setFilterValue("previous_mode", this.previousMode, false);
+          this.setFilterValue("previous_mode", this.previousMode);
         } else {
           this.previousMode = previous_mode;
         }
@@ -415,23 +413,21 @@
 
           this.setFilterValue(
             "start_date",
-            this.startDate.format("YYYY-MM-DD"),
-            false
+            this.startDate.format("YYYY-MM-DD")
           );
           this.setFilterValue(
             "end_date",
-            this.endDate.format("YYYY-MM-DD"),
-            false
+            this.endDate.format("YYYY-MM-DD")
           );
-          this.setFilterValue("date", this.date.format("YYYY-MM-DD"), false);
+          this.setFilterValue("date", this.date.format("YYYY-MM-DD"));
           const prevStartDate = includePrevious
             ? this.refStart.format("YYYY-MM-DD")
             : "";
           const prevEndDate = includePrevious
             ? this.refEnd.format("YYYY-MM-DD")
             : "";
-          this.setFilterValue("prev_start_date", prevStartDate, false);
-          this.setFilterValue("prev_end_date", prevEndDate, true);
+          this.setFilterValue("prev_start_date", prevStartDate);
+          this.setFilterValue("prev_end_date", prevEndDate);
         }
       },
     },

--- a/visualizations/frontend/filters/date_range_simple.html
+++ b/visualizations/frontend/filters/date_range_simple.html
@@ -146,13 +146,11 @@
 
         this.setFilterValue(
           "start_date",
-          this.startDate.format("YYYY-MM-DD"),
-          false
+          this.startDate.format("YYYY-MM-DD")
         );
         this.setFilterValue(
           "end_date",
-          this.endDate.format("YYYY-MM-DD"),
-          false
+          this.endDate.format("YYYY-MM-DD")
         );
 
         var start = this.startDate.clone();
@@ -184,17 +182,15 @@
           }
         }
 
-        this.setFilterValue("date_preset", this.datePreset, false);
-        this.setFilterValue("previous_mode", this.previousMode, false);
+        this.setFilterValue("date_preset", this.datePreset);
+        this.setFilterValue("previous_mode", this.previousMode);
         this.setFilterValue(
           "prev_start_date",
-          this.refStart.format("YYYY-MM-DD"),
-          false
+          this.refStart.format("YYYY-MM-DD")
         );
         this.setFilterValue(
           "prev_end_date",
           this.refEnd.format("YYYY-MM-DD"),
-          true
         );
         console.log("Set values");
       },
@@ -248,7 +244,7 @@
         var date_preset = this.getFilterValue("date_preset");
         if (date_preset == null) {
           this.datePreset = "last90days";
-          this.setFilterValue("date_preset", this.datePreset, false);
+          this.setFilterValue("date_preset", this.datePreset);
         } else {
           this.datePreset = date_preset;
         }
@@ -258,7 +254,7 @@
           if (this.datePreset == "mtd" || this.datePreset == "ytd")
             this.previousMode = "year";
           else this.previousMode = "period";
-          this.setFilterValue("previous_mode", this.previousMode, false);
+          this.setFilterValue("previous_mode", this.previousMode);
         } else {
           this.previousMode = previous_mode;
         }
@@ -284,23 +280,19 @@
 
           this.setFilterValue(
             "start_date",
-            this.startDate.format("YYYY-MM-DD"),
-            false
+            this.startDate.format("YYYY-MM-DD")
           );
           this.setFilterValue(
             "end_date",
-            this.endDate.format("YYYY-MM-DD"),
-            false
+            this.endDate.format("YYYY-MM-DD")
           );
           this.setFilterValue(
             "prev_start_date",
-            this.refStart.format("YYYY-MM-DD"),
-            false
+            this.refStart.format("YYYY-MM-DD")
           );
           this.setFilterValue(
             "prev_end_date",
-            this.refEnd.format("YYYY-MM-DD"),
-            true
+            this.refEnd.format("YYYY-MM-DD")
           );
         }
       },

--- a/visualizations/frontend/filters/multi_selector.html
+++ b/visualizations/frontend/filters/multi_selector.html
@@ -106,8 +106,7 @@
         }
         return this.setFilterValue(
           "selected_items",
-          this.selected_internal,
-          true
+          this.selected_internal
         );
       },
       handleMenuMargin() {
@@ -149,7 +148,7 @@
           this.handleMenuMargin();
           const selected = value.map((item) => item.id).join("|");
           this.selected_internal = selected;
-          this.setFilterValue("selected_items", selected, true);
+          this.setFilterValue("selected_items", selected);
           if (!value || !value.length) {
             this.unsetFilterValue("selected_items", true);
           }

--- a/visualizations/frontend/filters/search_filter.html
+++ b/visualizations/frontend/filters/search_filter.html
@@ -39,7 +39,7 @@
         },
         set(value) {
           this.text_internal = value;
-          this.setFilterValue("query", this.text_internal, true);
+          this.setFilterValue("query", this.text_internal);
         },
       },
     },
@@ -55,7 +55,7 @@
           return;
         }
         this.queryText = this.text_internal;
-        this.setFilterValue("query", this.text_internal, true);
+        this.setFilterValue("query", this.text_internal);
       },
       onEnter(e) {
         if (e.keyCode === 13) {

--- a/visualizations/frontend/filters/select_filter.html
+++ b/visualizations/frontend/filters/select_filter.html
@@ -75,7 +75,7 @@
     methods: {
       selectItem(index) {
         this.selected_internal = this.options[index];
-        this.setFilterValue("dropdown", this.selected_internal, true);
+        this.setFilterValue("dropdown", this.selected_internal);
         this.showMenu = false;
       },
       onVisualizationInit() {
@@ -93,7 +93,7 @@
         } else {
           return;
         }
-        this.setFilterValue("dropdown", this.selected_internal, true);
+        this.setFilterValue("dropdown", this.selected_internal);
       },
     },
   };

--- a/visualizations/frontend/filters/table_search.html
+++ b/visualizations/frontend/filters/table_search.html
@@ -62,7 +62,7 @@
         },
         set(value) {
           this.text_internal = encodeURI(value);
-          this.setFilterValue("selected", this.text_internal, true);
+          this.setFilterValue("selected", this.text_internal);
         },
       },
     },
@@ -119,7 +119,7 @@
       onVisualizationInit() {
         const initial_value = this.getFilterValue("selected");
         this.text_internal = initial_value || "";
-        this.setFilterValue("selected", encodeURI(this.text_internal), true);
+        this.setFilterValue("selected", encodeURI(this.text_internal));
         return this.text_internal;
       },
       select(row) {

--- a/visualizations/frontend/filters/toggle.html
+++ b/visualizations/frontend/filters/toggle.html
@@ -46,7 +46,7 @@
         },
         set(value) {
           this.checked_internal = value;
-          this.setFilterValue("checkbox", this.checked_internal, true);
+          this.setFilterValue("checkbox", this.checked_internal);
         },
       },
     },
@@ -57,10 +57,10 @@
 
         if (initial_value) {
           this.checked_internal = initial_value === "true";
-          this.setFilterValue("checkbox", this.checked_internal, true);
+          this.setFilterValue("checkbox", this.checked_internal);
         } else {
           this.checked_internal = false;
-          this.setFilterValue("checkbox", false, true);
+          this.setFilterValue("checkbox", false);
         }
       },
     },

--- a/visualizations/frontend/filters/v2/TCalendarPicker.vue
+++ b/visualizations/frontend/filters/v2/TCalendarPicker.vue
@@ -200,20 +200,12 @@ export default {
     apply() {
       this.pickerOpened = false;
       if (this.pickerMode == "single") {
-        this.setFilterValue("date", this.date.format("YYYY-MM-DD"), false);
+        this.setFilterValue("date", this.date.format("YYYY-MM-DD"));
       } else {
-        this.setFilterValue(
-          "start_date",
-          this.startDate.format("YYYY-MM-DD"),
-          false
-        );
-        this.setFilterValue(
-          "end_date",
-          this.endDate.format("YYYY-MM-DD"),
-          false
-        );
+        this.setFilterValue("start_date", this.startDate.format("YYYY-MM-DD"));
+        this.setFilterValue("end_date", this.endDate.format("YYYY-MM-DD"));
       }
-      this.setFilterValue("date_preset", this.datePreset, false);
+      this.setFilterValue("date_preset", this.datePreset);
     },
     presetChange(event) {
       this.datePreset = event.key;

--- a/visualizations/frontend/filters/v2/TCheckboxSwitch.vue
+++ b/visualizations/frontend/filters/v2/TCheckboxSwitch.vue
@@ -25,11 +25,11 @@ export default {
     onVisualizationInit() {
       const initial_value = this.getFilterValue("checkbox");
       this.value = initial_value === "true";
-      this.setFilterValue("checkbox", this.value, true);
+      this.setFilterValue("checkbox", this.value);
     },
     toggled(value) {
       this.value = value;
-      this.setFilterValue("checkbox", this.value, true);
+      this.setFilterValue("checkbox", this.value);
     },
   },
 };

--- a/visualizations/frontend/filters/v2/TInput.vue
+++ b/visualizations/frontend/filters/v2/TInput.vue
@@ -39,17 +39,17 @@ export default {
       } else if (this.config.default_value) {
         // Default value from layer
         this.value = this.config.default_value;
-        this.setFilterValue("query", this.value, true);
+        this.setFilterValue("query", this.value);
       } else if (this.defaultValue) {
         // Default value from prop
         this.value = this.defaultValue;
-        this.setFilterValue("query", this.value, true);
+        this.setFilterValue("query", this.value);
       } else {
         return;
       }
     },
     updateUrlParam() {
-      this.setFilterValue("query", this.value, true);
+      this.setFilterValue("query", this.value);
     },
   },
 };

--- a/visualizations/frontend/filters/v2/TInput.vue
+++ b/visualizations/frontend/filters/v2/TInput.vue
@@ -36,7 +36,7 @@ export default {
       if (initial_value) {
         // Value from url param.
         this.value = initial_value;
-      } else if (this.config.default_value) {
+      } else if (this.config?.default_value) {
         // Default value from layer
         this.value = this.config.default_value;
         this.setFilterValue("query", this.value, this.defaultValue);
@@ -50,6 +50,10 @@ export default {
     },
     updateUrlParam() {
       this.setFilterValue("query", this.value, this.defaultValue);
+    },
+    reset() {
+      this.value = this.defaultValue;
+      this.updateUrlParam();
     },
   },
 };

--- a/visualizations/frontend/filters/v2/TInput.vue
+++ b/visualizations/frontend/filters/v2/TInput.vue
@@ -39,17 +39,17 @@ export default {
       } else if (this.config.default_value) {
         // Default value from layer
         this.value = this.config.default_value;
-        this.setFilterValue("query", this.value);
+        this.setFilterValue("query", this.value, this.defaultValue);
       } else if (this.defaultValue) {
         // Default value from prop
         this.value = this.defaultValue;
-        this.setFilterValue("query", this.value);
+        this.setFilterValue("query", this.value, this.defaultValue);
       } else {
         return;
       }
     },
     updateUrlParam() {
-      this.setFilterValue("query", this.value);
+      this.setFilterValue("query", this.value, this.defaultValue);
     },
   },
 };

--- a/visualizations/frontend/filters/v2/TMultiSelector.vue
+++ b/visualizations/frontend/filters/v2/TMultiSelector.vue
@@ -82,12 +82,15 @@
         <span
           class="inline-flex items-center justify-end"
           :class="checked.length ? 'text-[#145DEB]' : 'text-[#727184]'"
-          @click="selectUnselect"
         >
           <t-loading-spinner v-if="isExpanded && loading" position="relative" />
-          <span v-else>
-            {{ checked.length < menu.length ? "Select All" : "Reset" }}
+          <span
+            v-else-if="checked.length < menu.length"
+            @click="selectUnselect"
+          >
+            Select All
           </span>
+          <span v-else @click="reset"> Reset </span>
         </span>
         <span @click="showSelected = !showSelected">
           {{ showSelected ? "Show all" : "Only show selected" }}
@@ -297,6 +300,18 @@ export default {
       }
       this.updateUrlParam();
     }, 750),
+    reset() {
+      if (this.defaultValue) {
+        this.checked = this.defaultValue.split("|");
+      } else {
+        this.checked = [];
+      }
+      this.setFilterValue(
+        "selected_items",
+        this.checked.join("|"),
+        this.defaultValue
+      );
+    },
     updateUrlParam(value) {
       if (value) {
         this.checked = [...value];

--- a/visualizations/frontend/filters/v2/TMultiSelector.vue
+++ b/visualizations/frontend/filters/v2/TMultiSelector.vue
@@ -281,7 +281,11 @@ export default {
         this.checked = initial_value.split("|");
       } else if (this.defaultValue) {
         this.checked = this.defaultValue.split("|");
-        this.setFilterValue("selected_items", this.defaultValue);
+        this.setFilterValue(
+          "selected_items",
+          this.defaultValue,
+          this.defaultValue
+        );
       }
     },
     selectUnselect: _.debounce(function () {
@@ -298,7 +302,11 @@ export default {
         this.checked = [...value];
       }
 
-      this.setFilterValue("selected_items", this.checked.join("|"));
+      this.setFilterValue(
+        "selected_items",
+        this.checked.join("|"),
+        this.defaultValue
+      );
     },
     onDropdownOpen() {
       this.fetchLayerData();

--- a/visualizations/frontend/filters/v2/TMultiSelector.vue
+++ b/visualizations/frontend/filters/v2/TMultiSelector.vue
@@ -90,7 +90,7 @@
           >
             Select All
           </span>
-          <span v-else @click="reset"> Reset </span>
+          <button v-else @click="reset">Reset</button>
         </span>
         <span @click="showSelected = !showSelected">
           {{ showSelected ? "Show all" : "Only show selected" }}

--- a/visualizations/frontend/filters/v2/TMultipleValueInput.vue
+++ b/visualizations/frontend/filters/v2/TMultipleValueInput.vue
@@ -71,10 +71,10 @@ export default {
           .filter((id) => this.values.indexOf(id) > -1)
           .join("|");
       }
-      this.setFilterValue("selected_items", urlParams, true);
+      this.setFilterValue("selected_items", urlParams);
     },
     update(item) {
-      this.setFilterValue("selected_items", item.join("|"), true);
+      this.setFilterValue("selected_items", item.join("|"));
     },
   },
 };

--- a/visualizations/frontend/filters/v2/TRangeInput.vue
+++ b/visualizations/frontend/filters/v2/TRangeInput.vue
@@ -59,7 +59,7 @@ export default {
         return minInternal ? parseInt(minInternal) : this.minValue;
       },
       set(val) {
-        this.setFilterValue("min", val, true);
+        this.setFilterValue("min", val);
         return val;
       },
     },
@@ -69,7 +69,7 @@ export default {
         return maxInternal ? parseInt(maxInternal) : this.maxValue;
       },
       set(val) {
-        this.setFilterValue("max", val, true);
+        this.setFilterValue("max", val);
         return val;
       },
     },

--- a/visualizations/frontend/filters/v2/TRangeSlider.vue
+++ b/visualizations/frontend/filters/v2/TRangeSlider.vue
@@ -57,13 +57,13 @@ export default {
     },
     handleDragend(e) {
       this.dragging = false;
-      this.setFilterValue("value", this.value, true);
+      this.setFilterValue("value", this.value);
     },
     handleClick(e) {
       this.dragging = true;
       this.handlePlacement(e.clientX);
       this.dragging = false;
-      this.setFilterValue("value", this.value, true);
+      this.setFilterValue("value", this.value);
     },
     handlePlacement(clickPos) {
       const container = this.$refs.rangeContainer;
@@ -88,7 +88,7 @@ export default {
         !internalValue || internalValue < this.min ? this.min : internalValue;
       const pos = ((this.value - this.min) * 100) / (this.max - this.min);
       this.left = pos;
-      this.setFilterValue("value", this.value, true);
+      this.setFilterValue("value", this.value);
     },
   },
 };

--- a/visualizations/frontend/filters/v2/TSearchInput.vue
+++ b/visualizations/frontend/filters/v2/TSearchInput.vue
@@ -44,17 +44,17 @@ export default {
       } else if (this.config.default_value) {
         // Default value from layer
         this.value = this.config.default_value;
-        this.setFilterValue("query", this.value);
+        this.setFilterValue("query", this.value, this.defaultValue);
       } else if (this.defaultValue) {
         // Default value from prop
         this.value = this.defaultValue;
-        this.setFilterValue("query", this.value);
+        this.setFilterValue("query", this.value, this.defaultValue);
       } else {
         return;
       }
     },
     updateUrlParam() {
-      this.setFilterValue("query", this.value);
+      this.setFilterValue("query", this.value, this.defaultValue);
     },
   },
 };

--- a/visualizations/frontend/filters/v2/TSearchInput.vue
+++ b/visualizations/frontend/filters/v2/TSearchInput.vue
@@ -44,17 +44,17 @@ export default {
       } else if (this.config.default_value) {
         // Default value from layer
         this.value = this.config.default_value;
-        this.setFilterValue("query", this.value, true);
+        this.setFilterValue("query", this.value);
       } else if (this.defaultValue) {
         // Default value from prop
         this.value = this.defaultValue;
-        this.setFilterValue("query", this.value, true);
+        this.setFilterValue("query", this.value);
       } else {
         return;
       }
     },
     updateUrlParam() {
-      this.setFilterValue("query", this.value, true);
+      this.setFilterValue("query", this.value);
     },
   },
 };

--- a/visualizations/frontend/filters/v2/TSelect.vue
+++ b/visualizations/frontend/filters/v2/TSelect.vue
@@ -171,7 +171,7 @@ export default {
         this.selected_internal = initial_value;
       } else if (this.defaultValue) {
         this.selected_internal = this.defaultValue;
-        this.setFilterValue("dropdown", this.defaultValue);
+        this.setFilterValue("dropdown", this.defaultValue, this.defaultValue);
       }
     },
     onFiltersUpdated() {
@@ -185,7 +185,11 @@ export default {
         this.selected_internal = item.value;
       }
 
-      this.setFilterValue("dropdown", this.selected_internal);
+      this.setFilterValue(
+        "dropdown",
+        this.selected_internal,
+        this.defaultValue
+      );
     },
     onDropdownOpen() {
       this.fetchLayerData();

--- a/visualizations/frontend/filters/v2/TSelect.vue
+++ b/visualizations/frontend/filters/v2/TSelect.vue
@@ -7,9 +7,7 @@
       </div>
 
       <div class="flex items-center gap-1">
-        <div v-if="label">
-          {{ label }}{{ selected_internal ? ":" : "" }}
-        </div>
+        <div v-if="label">{{ label }}{{ selected_internal ? ":" : "" }}</div>
         <div class="font-normal">
           {{ selected_internal }}
         </div>
@@ -187,7 +185,7 @@ export default {
         this.selected_internal = item.value;
       }
 
-      this.setFilterValue("dropdown", this.selected_internal, true);
+      this.setFilterValue("dropdown", this.selected_internal);
     },
     onDropdownOpen() {
       this.fetchLayerData();

--- a/visualizations/frontend/filters/v2/TTags.vue
+++ b/visualizations/frontend/filters/v2/TTags.vue
@@ -203,7 +203,7 @@ export default {
       this.init = true;
     },
     updateUrlParams() {
-      this.setFilterValue("selected_items", this.checked.join("|"), true);
+      this.setFilterValue("selected_items", this.checked.join("|"));
     },
   },
 };

--- a/visualizations/frontend/other/TSelectColumns.vue
+++ b/visualizations/frontend/other/TSelectColumns.vue
@@ -128,11 +128,10 @@ export default {
     updateChecked: _.debounce(function () {
       this.$emit("updateFilteredColumns", this.checked);
       const selectColumnLabels = this.checked.map((c) => c.label);
-      this.setFilter({
-        name: this.urlParamName,
-        value: selectColumnLabels.join("|"),
-        persist: false,
-      });
+      this.setFilterValue(
+        this.urlParamName,
+        selectColumnLabels.join("|"),
+      );
     }, 750),
   },
 };

--- a/visualizations/frontend/other/TSelectColumns.vue
+++ b/visualizations/frontend/other/TSelectColumns.vue
@@ -128,9 +128,14 @@ export default {
     updateChecked: _.debounce(function () {
       this.$emit("updateFilteredColumns", this.checked);
       const selectColumnLabels = this.checked.map((c) => c.label);
+      const defaultColumns = this?.modifiableColumns
+        .filter((mc) => mc.displayByDefault)
+        .map((mc)=> mc.displayColumn)
       this.setFilterValue(
         this.urlParamName,
         selectColumnLabels.join("|"),
+        defaultColumns,
+        true,
       );
     }, 750),
   },

--- a/visualizations/frontend/other/TSelectColumns.vue
+++ b/visualizations/frontend/other/TSelectColumns.vue
@@ -126,17 +126,21 @@ export default {
       this.$emit("updateFilteredColumns", this.checked);
     },
     updateChecked: _.debounce(function () {
+        console.log('updateChecked')
       this.$emit("updateFilteredColumns", this.checked);
       const selectColumnLabels = this.checked.map((c) => c.label);
       const defaultColumns = this?.modifiableColumns
         .filter((mc) => mc.displayByDefault)
         .map((mc)=> mc.displayColumn)
+        console.log('updateChecked defaultColumns', defaultColumns)
+
       this.setFilterValue(
         this.urlParamName,
         selectColumnLabels.join("|"),
         defaultColumns,
         true,
       );
+        console.log('updateChecked passed')
     }, 750),
   },
 };

--- a/visualizations/frontend/other/TSelectColumns.vue
+++ b/visualizations/frontend/other/TSelectColumns.vue
@@ -111,7 +111,6 @@ export default {
   methods: {
     selectAll() {
       this.checked = [...this.internalColumns];
-      const visibleColumnlabels = this.checked.map((c) => c.label);
     },
     reset() {
       this.checked = [];
@@ -126,21 +125,18 @@ export default {
       this.$emit("updateFilteredColumns", this.checked);
     },
     updateChecked: _.debounce(function () {
-        console.log('updateChecked')
       this.$emit("updateFilteredColumns", this.checked);
       const selectColumnLabels = this.checked.map((c) => c.label);
       const defaultColumns = this?.modifiableColumns
         .filter((mc) => mc.displayByDefault)
-        .map((mc)=> mc.displayColumn)
-        console.log('updateChecked defaultColumns', defaultColumns)
-
-      this.setFilterValue(
-        this.urlParamName,
-        selectColumnLabels.join("|"),
-        defaultColumns,
-        true,
-      );
-        console.log('updateChecked passed')
+        .map((mc) => mc.displayColumn);
+      this.setFilter({
+        name: this.urlParamName,
+        value: selectColumnLabels.join("|"),
+        defaultValue: defaultColumns.join("|"),
+        persist: false,
+        skipOnReset: true,
+      });
     }, 750),
   },
 };

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -537,7 +537,8 @@ export default {
   mounted() {
     this.fetchTotalRows();
 
-    this.internalRowsPerPage = this.getFilterState("tableRowsPerPage") || this.rowsPerPage;
+    this.internalRowsPerPage =
+      this.getFilterState("tableRowsPerPage") || this.rowsPerPage;
 
     const modifiableColumnsFilter = this.getFilterState(
       this.modifiableColumnsFilterName

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -1322,7 +1322,7 @@ export default {
           urlparam: filterName,
         });
       }
-      this.setFilterValue(filterName, filterValue);
+      this.setFilterValue(filterName, filterValue, undefined, true);
     },
   },
 };


### PR DESCRIPTION
### What this does

This PR converts the format of filters in the topcoat core frontend from an object in the form of 
`
{
  filterName1: filterValue1,
  filterName2: filterValue2,
...
}
`

into an array in the format of:
`
  [
    { 
       name: filterName1,
       value: filterValue1,
       defaultValue: <optional default value>, 
       skipOnReset: <default to false, but can be set to true as appropriate>
    },
  ...
  ]
`

This update allows the code to reset "all" filters while leaving things like modify columns, sorting, "Issues buy" option etc. alone even though under the hood they work like filters.

Additionally it allows default values to be set on a filter, for example issue status, so that resetting the filters does not simply remove them but rather reverts the state back to the what it was before the user interacted with the page. 

It does not change the format of the filters on the backend. There is no point sending default values or whether or not a filter should be skipped on reset to the back end since all of that logic is on the front end, instead filters are sent in the original format to the back end. 

### Additional changes

Note that the addition of `...mapGetters("page", ["getFilterState"]),` in common_mixin is so that topcoat developers don't have to manually find the filter before testing its value. 

### Notes for the reviewer

To test, this requires updates in both topcoat-public and topcoat-reports so check out the 'feat/resetable_filters' topcoat-reports branch and run a build and sync modules. 