### PR TITLE
Add support for numerical issue severities

### DIFF
--- a/library/components/tableComponents/IssueSeverityIcon.vue
+++ b/library/components/tableComponents/IssueSeverityIcon.vue
@@ -1,28 +1,28 @@
 <template>
   <div>
     <div
-      v-if="severity === 'Critical'"
+      v-if="['Critical', 4].includes(severity)"
       class="text-[11px] bg-[#ba1515] w-[20px] h-[20px] text-[#ffffff] inline-flex items-center justify-center rounded-[2px]"
       title="Critical Issues"
     >
       C
     </div>
     <div
-      v-if="severity === 'High'"
+      v-else-if="['High', 3].includes(severity)"
       class="text-[11px] bg-[#cc4f19] w-[20px] h-[20px] text-[#ffffff] inline-flex items-center justify-center rounded-[2px]"
       title="High Issues"
     >
       H
     </div>
     <div
-      v-if="severity === 'Medium'"
+      v-else-if="['Medium', 2].includes(severity)"
       class="text-[11px] bg-[#f9a11b] w-[20px] h-[20px] text-[#ffffff] inline-flex items-center justify-center rounded-[2px]"
       title="Medium Issues"
     >
       M
     </div>
     <div
-      v-if="severity === 'Low'"
+      v-else-if="['Low', 1].includes(severity) "
       class="text-[11px] bg-[#8e8d92] w-[20px] h-[20px] text-[#ffffff] inline-flex items-center justify-center rounded-[2px]"
       title="Low Issues"
     >
@@ -36,10 +36,10 @@ export default {
   name: "IssueSeverityIcon",
   props: {
     severity: {
-      type: String,
+      type: [String, Number],
       required: true,
       validator: function (value) {
-        return ["Critical", "High", "Medium", "Low"].includes(value);
+        return ["Critical", "High", "Medium", "Low", 1, 2, 3, 4].includes(value);
       },
     },
   },


### PR DESCRIPTION
To test, check out the feat/severity-sorting branch and update config.yml to use this branch. Sorting by the severity in the issues-detail table should now respect the actual severity, not the alphabetical order of Critical, High, Low, and Medium.