### PR TITLE
Feat/default sort table prop

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -371,17 +371,18 @@ export default {
       default: () => [],
     },
     defaultSort: {
-        type: Array,
-        default: null,
-        validator(sorts) {
-            if(sorts === null) return true;
-            sorts.forEach((sort)=>{
-                if(!sort.column || typeof sort.column !== "string") return false;
-                if(!sort.direction || !["ASC", "DESC"].includes(sort.direction)) return false;
-            })
-            return true;
-        },
-    }
+      type: Array,
+      default: null,
+      validator(sorts) {
+        if (sorts === null) return true;
+        sorts.forEach((sort) => {
+          if (!sort.column || typeof sort.column !== "string") return false;
+          if (!sort.direction || !["ASC", "DESC"].includes(sort.direction))
+            return false;
+        });
+        return true;
+      },
+    },
   },
   emits: {
     "update:selectedItem": null,
@@ -605,11 +606,11 @@ export default {
       // the default sort direction
       if (setColumnSort && this.sort !== "none") {
         let sortableColumns = cols.map((col) => {
-            const sortCol = {
-                column: col.property,
-                direction: this.sortDirection,
-            };
-            return sortCol;
+          const sortCol = {
+            column: col.property,
+            direction: this.sortDirection,
+          };
+          return sortCol;
         });
 
         const urlSortConfig = this.getUrlSortConfiguration();
@@ -627,19 +628,19 @@ export default {
           // append remaining sortable but not sorted columns to the configuration
           sortConfig = sortConfig.concat(sortableColumns);
           sortableColumns = sortConfig;
-        } else if(this.defaultSort){
-            let sortConfig = [];
-            this.defaultSort.forEach((ds) => {
-                if (sortableColumns.find((sc) => sc.column === ds.column)) {
-                sortConfig.push(ds);
-                sortableColumns = sortableColumns.filter(
-                    (sc) => sc.column !== ds.column
-                );
-                }
-            });
-            // append remaining sortable but not sorted columns to the configuration
-            sortConfig = sortConfig.concat(sortableColumns);
-            sortableColumns = sortConfig;
+        } else if (this.defaultSort) {
+          let sortConfig = [];
+          this.defaultSort.forEach((ds) => {
+            if (sortableColumns.find((sc) => sc.column === ds.column)) {
+              sortConfig.push(ds);
+              sortableColumns = sortableColumns.filter(
+                (sc) => sc.column !== ds.column
+              );
+            }
+          });
+          // append remaining sortable but not sorted columns to the configuration
+          sortConfig = sortConfig.concat(sortableColumns);
+          sortableColumns = sortConfig;
         }
 
         this.excludeFromSort.forEach((efs) => {

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -374,12 +374,14 @@ export default {
       type: Array,
       default: null,
       validator(sorts) {
-        if (sorts === null) return true;
-        sorts.forEach((sort) => {
-          if (!sort.column || typeof sort.column !== "string") return false;
-          if (!sort.direction || !["ASC", "DESC"].includes(sort.direction))
-            return false;
-        });
+        const directionList = ["ASC", "DESC"];
+        if (sorts) {
+          return sorts.every(
+            (sort) =>
+              directionList.includes(sort?.direction) &&
+              typeof sort?.column === "string"
+          );
+        }
         return true;
       },
     },

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -630,13 +630,13 @@ export default {
           // append remaining sortable but not sorted columns to the configuration
           sortConfig = sortConfig.concat(sortableColumns);
           sortableColumns = sortConfig;
-        } else if( this.defaultSort){
+        } else if(this.defaultSort){
             let sortConfig = [];
             this.defaultSort.forEach((ds) => {
                 if (sortableColumns.find((sc) => sc.column === ds.column)) {
                 sortConfig.push(ds);
                 sortableColumns = sortableColumns.filter(
-                    (sc) => sc.column !== usc.column
+                    (sc) => sc.column !== ds.column
                 );
                 }
             });

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -603,9 +603,6 @@ export default {
       //
       // If the url includes sortable column configuration, use that to determine direction and ignore
       // the default sort direction
-      //
-      // Any columns in the url sortable configuration that are not in defaultSort should be ignored
-      // when configuring the sorting
       if (setColumnSort && this.sort !== "none") {
         let sortableColumns = cols.map((col) => {
             const sortCol = {


### PR DESCRIPTION
To test, check out the meg-dev branch in topcoat-reports, sync and build, and open the issues detail report. The "SCORE" and "ISSUE" columns should both be sorted descending with the descending sort icon.