### PR TITLE
Support relative urls with base url as window location

### DIFF
--- a/library/components/TUrl.vue
+++ b/library/components/TUrl.vue
@@ -87,11 +87,13 @@ export default {
         urlParamString = params.toString();
       }
 
+      const url = new URL(this.url, window.location.origin).href;
+
       if (urlParamString.length > 0) {
-        return `${this.url}?${urlParamString}`;
+        return `${url}?${urlParamString}`;
       }
 
-      return this.url;
+      return url;
     },
   },
 };


### PR DESCRIPTION
Allows for the TUrl component to handle relative (without scheme, host or port) by using the origin as a base url.

Absolute urls continue to work as before.