### PR TITLE
Feat/modifiable rows per page

### DIFF
--- a/library/components/TDropdown.vue
+++ b/library/components/TDropdown.vue
@@ -4,6 +4,7 @@
     class="relative w-auto font-sans cursor-pointer dropdown-filter"
   >
     <div
+      ref="handle"
       class="rounded cursor-pointer"
       :class="!disableActiveClass && activeClass"
       @click="handlePopup"
@@ -54,6 +55,14 @@ export default {
       type: Boolean,
       default: false,
     },
+    alignPopupAbove: {
+      type: Boolean,
+      default: false,
+    },
+    alignPopupRight: {
+      type: Boolean,
+      default: false,
+    },
   },
   data: () => ({
     alignClass: "",
@@ -94,12 +103,26 @@ export default {
         this.closePopup();
       }
     });
+    return "";
   },
   methods: {
     alignPopup() {
       const element = this.$refs.popup;
 
       if (element) {
+        if (this.alignPopupAbove) {
+          const handleElement = this.$refs.handle;
+          const heightOfDropdown = handleElement
+            ? handleElement.offsetHeight
+            : 0;
+          const moveUpAmount = element.offsetHeight + heightOfDropdown;
+          element.style.transform = `translateY(-${moveUpAmount}px)`;
+        }
+
+        if (this.alignPopupRight) {
+          return (this.alignClass = "right-0");
+        }
+
         const bounding = element.getBoundingClientRect();
         const availableWidth = window.innerWidth;
 

--- a/library/components/tableComponents/SnykPager.vue
+++ b/library/components/tableComponents/SnykPager.vue
@@ -16,7 +16,7 @@
           slot="handle"
           class="flex items-center gap-1 p-1 text-medium font-large"
         >
-          <span>{{ itemsPerPage }} Per Page </span>
+          <span>{{ itemsPerPage }} Per Page</span>
           <menu-down-icon size="20" />
         </div>
 
@@ -25,12 +25,13 @@
           <div class="px-[8px] pt-[4px] pb-[6px] w-full">
             <ul class="max-h-[320px] overflow-auto">
               <li
-                v-for="itemsPerPageOption in [10, 50, 100, 500, 1000]"
+                v-for="itemsPerPageOption in itemsPerPageOptions"
                 :key="itemsPerPageOption"
                 class="flex justify-between m-[16px] text-medium cursor-pointer text-[#4B5563]"
               >
                 <div
                   class="flex items-center justify-between w-full leading-[16.41px]"
+                  @click="$emit('updateItemsPerPage', itemsPerPageOption)"
                 >
                   <div
                     v-if="itemsPerPageOption === itemsPerPage"
@@ -107,8 +108,17 @@ export default {
   props: {
     numberOfItems: { type: Number, required: true },
     itemsPerPage: { type: Number, default: 10 },
+    itemsPerPageOptions: {
+      type: Array,
+      default: () => [10, 50, 100, 500, 1000],
+    },
   },
-  emits: ["updateStartIndex", "updateEndIndex", "setResetFunction"],
+  emits: [
+    "updateStartIndex",
+    "updateEndIndex",
+    "setResetFunction",
+    "updateItemsPerPage",
+  ],
   data() {
     return {
       internalPage: 1,

--- a/library/components/tableComponents/SnykPager.vue
+++ b/library/components/tableComponents/SnykPager.vue
@@ -19,7 +19,7 @@
         </div>
 
         <!-- Popup Contents -->
-        <div attrs.slot="outside">
+        <div attrs.slot="outside" style="transform: translateY(-190px)">
           <div class="px-[8px] pt-[4px] pb-[6px] w-full">
             <ul class="max-h-[320px] overflow-auto">
               <li

--- a/library/components/tableComponents/SnykPager.vue
+++ b/library/components/tableComponents/SnykPager.vue
@@ -8,6 +8,8 @@
       <t-dropdown
         :disable-active-class="true"
         class="absolute left-2 top-5 text-[15px] text-[#145DEB] font-large"
+        :align-popup-above="true"
+        :align-popup-right="true"
       >
         <!-- Handle -->
         <div
@@ -19,7 +21,7 @@
         </div>
 
         <!-- Popup Contents -->
-        <div attrs.slot="outside" style="transform: translateY(-190px)">
+        <div attrs.slot="outside">
           <div class="px-[8px] pt-[4px] pb-[6px] w-full">
             <ul class="max-h-[320px] overflow-auto">
               <li

--- a/library/components/tableComponents/SnykPager.vue
+++ b/library/components/tableComponents/SnykPager.vue
@@ -2,8 +2,52 @@
   <div>
     <div
       v-if="numberOfItems && numberOfItems > itemsPerPage"
-      class="pagination-footer flex justify-center relative"
+      class="pagination-footer flex justify-center relative h-8"
     >
+      <!-- Rows Per Page -->
+      <t-dropdown
+        :disable-active-class="true"
+        class="absolute left-2 top-5 text-[15px] text-[#145DEB] font-large"
+      >
+        <!-- Handle -->
+        <div
+          slot="handle"
+          class="flex items-center gap-1 p-1 text-medium font-large"
+        >
+          <span>{{ itemsPerPage }} Per Page </span>
+          <menu-down-icon size="20" />
+        </div>
+
+        <!-- Popup Contents -->
+        <div attrs.slot="outside">
+          <div class="px-[8px] pt-[4px] pb-[6px] w-full">
+            <ul class="max-h-[320px] overflow-auto">
+              <li
+                v-for="itemsPerPageOption in [10, 50, 100, 500, 1000]"
+                :key="itemsPerPageOption"
+                class="flex justify-between m-[16px] text-medium cursor-pointer text-[#4B5563]"
+              >
+                <div
+                  class="flex items-center justify-between w-full leading-[16.41px]"
+                >
+                  <div
+                    v-if="itemsPerPageOption === itemsPerPage"
+                    class="text-[#1f2937] selected-items-per-page"
+                  >
+                    {{ itemsPerPageOption.toLocaleString() }}
+                    <check-icon class="text-[#145DEB] ml-[8px]" size="20" />
+                  </div>
+                  <div v-else>
+                    {{ itemsPerPageOption.toLocaleString() }}
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </t-dropdown>
+
+      <!-- controls -->
       <ul
         id="pages"
         class="pagination-nav pagination-selector inline-flex pt-[16px]"
@@ -16,7 +60,11 @@
             <i class="fas fa-arrow-left"></i>
           </button>
         </li>
-        <li v-for="page in pageNumbersToShow" class="pagination-nav-item">
+        <li
+          v-for="page in pageNumbersToShow"
+          :key="page"
+          class="pagination-nav-item"
+        >
           <button
             class="h-8 minWidth text-[15px] font-medium leading-5 focus:outline-none"
             :class="[
@@ -38,11 +86,13 @@
           </button>
         </li>
       </ul>
+
+      <!-- totals -->
       <div
         class="absolute right-2 top-5 font-normal text-[#727184] text-[13px] leading-[18px]"
       >
-        Showing {{ startIndex + 1 }}- 
-        {{  Math.min(startIndex + itemsPerPage, numberOfItems) }}
+        Showing {{ startIndex + 1 }}-
+        {{ Math.min(startIndex + itemsPerPage, numberOfItems) }}
         of {{ numberOfItems.toLocaleString() }}
       </div>
     </div>
@@ -64,7 +114,7 @@ export default {
   },
   computed: {
     pageNumbersToShow() {
-      pageNumbersToShow = [];
+      let pageNumbersToShow = [];
       let pageToAdd = this.internalPage;
       let numberOfPagesAdded = 0;
 
@@ -158,5 +208,9 @@ export default {
 
 #pages {
   z-index: 2;
+}
+
+.selected-items-per-page {
+  display: flex;
 }
 </style>


### PR DESCRIPTION
To test, update the modules-> revision field in config.yml to "feat/modifiable_rows_per_page" and then run a sync and build. The tables with paging enabled should have a new option in the bottom left to update the number of rows to show that looks like [this](https://www.figma.com/proto/1Yt1eSMomCATi3wBUeG5tr/Patch-ProductUI?page-id=1806%3A127&node-id=10416%3A124168&viewport=-74%2C-818%2C0.43&scaling=min-zoom&starting-point-node-id=10416%3A124168).