### PR TITLE
Feat/add general search to TTagsSelector

### DIFF
--- a/visualizations/frontend/filters/TTagsSelector.vue
+++ b/visualizations/frontend/filters/TTagsSelector.vue
@@ -184,6 +184,10 @@ export default {
       type: Number,
       default: 5,
     },
+    searchFields: {
+      type: Array,
+      default: null,
+    },
   },
   data: () => ({
     selected: [],
@@ -310,14 +314,24 @@ export default {
       return (this.expanded = this.expanded.filter((k) => k !== key));
     },
     searchInObject(searchTerm, obj) {
-      for (const val of Object.values(obj)) {
+      const lowercaseSearchFields = this.searchFields
+        ? this.searchFields.map((field) => field.toLowerCase())
+        : null;
+      for (const key of Object.keys(obj)) {
         if (
-          val?.value
-            ?.toString()
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase())
+          !this.searchFields ||
+          lowercaseSearchFields.includes(key.toLowerCase()) ||
+          key.toLowerCase() === "value"
         ) {
-          return true;
+          const val = obj[key];
+          if (
+            val?.value
+              ?.toString()
+              .toLowerCase()
+              .includes(searchTerm.toLowerCase())
+          ) {
+            return true;
+          }
         }
       }
       return false;

--- a/visualizations/frontend/filters/TTagsSelector.vue
+++ b/visualizations/frontend/filters/TTagsSelector.vue
@@ -199,19 +199,7 @@ export default {
       for (let row of this.rows) {
         const key = row[this.tKeyColumn];
         const value = row[this.tValueColumn];
-        if (!key.value || !value.value) {
-          continue;
-        }
-
-        if (!this.selectedKey) {
-          if (!key.value.toLowerCase().includes(this.search.toLowerCase())) {
-            continue;
-          }
-        } else if (
-          !value.value.toLowerCase().includes(this.search.toLowerCase())
-        ) {
-          continue;
-        }
+        if (this.search && !this.searchInObject(this.search, row)) continue;
 
         const selected = this.selected.filter((s) => {
           if (s.key === key.value) {
@@ -320,6 +308,19 @@ export default {
         return this.expanded.push(key);
       }
       return (this.expanded = this.expanded.filter((k) => k !== key));
+    },
+    searchInObject(searchTerm, obj) {
+      for (const val of Object.values(obj)) {
+        if (
+          val?.value
+            ?.toString()
+            .toLowerCase()
+            .includes(searchTerm.toLowerCase())
+        ) {
+          return true;
+        }
+      }
+      return false;
     },
   },
 };

--- a/visualizations/frontend/filters/TTagsSelector.vue
+++ b/visualizations/frontend/filters/TTagsSelector.vue
@@ -313,19 +313,22 @@ export default {
       }
       return (this.expanded = this.expanded.filter((k) => k !== key));
     },
-    searchInObject(searchTerm, obj) {
+    searchInObject(searchTerm, row) {
+      const COLUMN_VALUE = "value";
       const lowercaseSearchFields = this.searchFields
         ? this.searchFields.map((field) => field.toLowerCase())
-        : null;
-      for (const key of Object.keys(obj)) {
+        : [];
+
+      for (const column of Object.keys(row)) {
         if (
           !this.searchFields ||
-          lowercaseSearchFields.includes(key.toLowerCase()) ||
-          key.toLowerCase() === "value"
+          lowercaseSearchFields.includes(column.toLowerCase()) ||
+          column.toLowerCase() === COLUMN_VALUE
         ) {
-          const val = obj[key];
+          const data = row[column];
+
           if (
-            val?.value
+            data?.value
               ?.toString()
               .toLowerCase()
               .includes(searchTerm.toLowerCase())


### PR DESCRIPTION
Goal: Allow users to search for text in related fields to a filter. For example, as user may not remember "CWE-502"  but does remember "Deserialization of Untrusted Data", so even though "Deserialization of Untrusted Data" is not shown to the user as part of the filter dropdown, allow users to search for it and it should match "CWE-502"  

To test:

- check out the meg-dev branch in the builder, then run a sync and build.
- Open issues details and select the cve filter
- In the search bar of the filter, verify that filtering the CVEs by their display values works as expected
- Verify that 'SQL Injection' returns all the CVEs, but that ''SQL Injection**s**' return none
- Verify that 'Use of Hard-coded Credentials' returns no CVEs
- Remove ' :searchFields="['TITLE']" ' from the issue details page.
- Verify that 'Use of Hard-coded Credentials' returns all the CVEs

[Jira ticket](https://snyksec.atlassian.net/browse/DP-355)

[Pitch](https://www.notion.so/snyk/Enable-CVE-CWE-filter-to-include-the-description-for-easier-searching-c78f93373641466481c47fe6a471711f)

Next Steps:
Update the layers for the CWE and CVE filter layers in topcoat-reports to include title, description, etc. fields. By default, the TTagsSelector will search those fields for the user-supplied search term so no further action in the vue files will be necessary unless a field is added to the layers that should not be searchable (e.g. id), at which point all fields that should be searched will need to be added to the "searchFields" prop. 