### PR TITLE
Fix/bugs in modifiable rows per page

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -537,14 +537,16 @@ export default {
   mounted() {
     this.fetchTotalRows();
 
-    this.internalRowsPerPage =
-      this.getFilterState("tableRowsPerPage") || this.rowsPerPage;
-    console.log("this.internalRowsPerPage ", this.internalRowsPerPage);
-    console.log("this.rowsPerPageOptions ", this.rowsPerPageOptions);
-    // Only allow valid rows per pages regardless of the url value or prop
-    if (!this.rowsPerPageOptions.includes(this.internalRowsPerPage)) {
-      this.internalRowsPerPage = this.rowsPerPageOptions[0];
-      this.setUrlFilter("tableRowsPerPage", this.internalRowsPerPage);
+    if (this.isPdf) {
+      this.internalRowsPerPage = 50;
+    } else {
+      this.internalRowsPerPage =
+        this.getFilterState("tableRowsPerPage") || this.rowsPerPage;
+      // Only allow valid rows per pages regardless of the url value or prop
+      if (!this.rowsPerPageOptions.includes(this.internalRowsPerPage)) {
+        this.internalRowsPerPage = this.rowsPerPageOptions[0];
+        this.setUrlFilter("tableRowsPerPage", this.internalRowsPerPage);
+      }
     }
 
     const modifiableColumnsFilter = this.getFilterState(

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -537,7 +537,15 @@ export default {
   mounted() {
     this.fetchTotalRows();
 
-    this.internalRowsPerPage = this.getFilterState("tableRowsPerPage") || this.rowsPerPage;
+    this.internalRowsPerPage =
+      this.getFilterState("tableRowsPerPage") || this.rowsPerPage;
+    console.log("this.internalRowsPerPage ", this.internalRowsPerPage);
+    console.log("this.rowsPerPageOptions ", this.rowsPerPageOptions);
+    // Only allow valid rows per pages regardless of the url value or prop
+    if (!this.rowsPerPageOptions.includes(this.internalRowsPerPage)) {
+      this.internalRowsPerPage = this.rowsPerPageOptions[0];
+      this.setUrlFilter("tableRowsPerPage", this.internalRowsPerPage);
+    }
 
     const modifiableColumnsFilter = this.getFilterState(
       this.modifiableColumnsFilterName


### PR DESCRIPTION
Ezra discovered a couple of bugs in the modifiable rows per page feature:

1. Users could update the url to a # of rows to show per page that was not one of the valid options
2. The PDF export should always (for now) export 50 rows regardless of what the filter is set to.

This PR addresses both bugs.

To test

- update the modules branch to "fix/bugs_in_modifiable_rows_per_page"
- add `:rows-per-page-options="[10, 20, 50]"` to a table with more than 50 rows
- select an option
- update the "tableRowsPerPage" in the url to an invalid option and press enter
- verify that the table shows 10 rows and the dropdown is set to "10 Per Page"
- Export a pdf and verify that it includes 50 rows