### PR TITLE
Add parseInt when setting Rows Per Page

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -542,6 +542,7 @@ export default {
     } else {
       this.internalRowsPerPage =
         this.getFilterState("tableRowsPerPage") || this.rowsPerPage;
+      this.internalRowsPerPage = parseInt(this.internalRowsPerPage, 10);
       // Only allow valid rows per pages regardless of the url value or prop
       if (!this.rowsPerPageOptions.includes(this.internalRowsPerPage)) {
         this.internalRowsPerPage = this.rowsPerPageOptions[0];


### PR DESCRIPTION
Goal: Setting the Rows to show per page based on the URL has regressed. The filter value is a string, not an integer so the check that the filter value is valid was failing resulting in the default number of rows per page always being used.

To test:

- In Issue Details, select 50 Rows Per Page and refresh
- Note that the Rows Per Page is now 10
- Update the revision in config.yml to "fix/rows_per_page_not_persisted"
- sync and build
- Again select 50 rows per page in Issues Details and refresh
- Verify that now the 50 rows per page selection is saved after refresh.