### PR TITLE
Remove legacy embed iframe references

### DIFF
--- a/library/components/Tile.vue
+++ b/library/components/Tile.vue
@@ -7,7 +7,7 @@
       </div>
     </div>
     <div v-else>
-      <div :style="{ height: is_iframe ? 'inherit' : height - 2 + 'px' }">
+      <div :style="{ height: height - 2 + 'px' }">
         <slot></slot>
       </div>
     </div>

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -1251,7 +1251,6 @@ export default {
           columns,
           dimensions,
           filters,
-          is_iframe,
           layers,
           load_phase,
           measures,


### PR DESCRIPTION
Remove references to the iframe property that was part of embeds. It's not defined anymore.