### PR TITLE
Added debounce to TTagsSelector

### DIFF
--- a/visualizations/frontend/filters/TTagsSelector.vue
+++ b/visualizations/frontend/filters/TTagsSelector.vue
@@ -285,7 +285,7 @@ export default {
         ? JSON.stringify(urlObject)
         : "";
       return this.setFilterValue("selected_items", urlValue);
-    }, 750),
+    }, 250),
     open() {
       if (this.loading) {
         return false;

--- a/visualizations/frontend/filters/TTagsSelector.vue
+++ b/visualizations/frontend/filters/TTagsSelector.vue
@@ -286,10 +286,6 @@ export default {
         : "";
       return _.debounce(this.setFilterValue("selected_items", urlValue), 750);
     },
-    removeFilter() {
-      return _.debounce(this.unsetFilterValue("selected_items"), 750);
-    },
-
     open() {
       if (this.loading) {
         return false;

--- a/visualizations/frontend/filters/TTagsSelector.vue
+++ b/visualizations/frontend/filters/TTagsSelector.vue
@@ -272,7 +272,7 @@ export default {
       });
       this.updateUrlValue();
     },
-    updateUrlValue() {
+    updateUrlValue: _.debounce(function () {
       const urlObject = {};
       for (let obj of this.selected) {
         if (urlObject[obj.key]) {
@@ -284,8 +284,8 @@ export default {
       const urlValue = Object.keys(urlObject).length
         ? JSON.stringify(urlObject)
         : "";
-      return _.debounce(this.setFilterValue("selected_items", urlValue), 750);
-    },
+      return this.setFilterValue("selected_items", urlValue);
+    }, 750),
     open() {
       if (this.loading) {
         return false;

--- a/visualizations/frontend/filters/TTagsSelector.vue
+++ b/visualizations/frontend/filters/TTagsSelector.vue
@@ -284,11 +284,12 @@ export default {
       const urlValue = Object.keys(urlObject).length
         ? JSON.stringify(urlObject)
         : "";
-      return this.setFilterValue("selected_items", urlValue);
+      return _.debounce(this.setFilterValue("selected_items", urlValue), 750);
     },
     removeFilter() {
-      this.unsetFilterValue("selected_items");
+      return _.debounce(this.unsetFilterValue("selected_items"), 750);
     },
+
     open() {
       if (this.loading) {
         return false;


### PR DESCRIPTION
Goal: Avoid race condition when fetching data where the filters have been updated but a previous result set is returned after the result for the latest severity filter change so data that does not match the selected filters is displayed to users.

To test:

- update the revision in config.yml to 'chore/add_debounce_to_TTagsSelector'
- sync and build modules
- open Issues Detail and add the severity filter
- rapidly select and deselect options and verify that the data is only fetched when there is a pause between updating the selections (the loading circles will appear when data is being fetched) and that the data stays in sync with the filters. 

