### PR TITLE
Chore/add way to apply css classes to the table based on column, row, row index, and/or column index

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -198,7 +198,7 @@
               :key="column.property"
               :ref="'rowCell_' + gindex + '_' + rindex + '_' + cindex"
               class="border-b border-[#D3D3D9] align-top py-[12px]"
-              :class="generateCellClasses({ column, cindex, rindex })"
+              :class="generateCellClasses({ column, cindex, row, rindex })"
             >
               <slot
                 :name="column.property"
@@ -1189,7 +1189,7 @@ export default {
     toggleRow(row) {
       row.detailRowOpen ? this.collapseRow(row) : this.expandRow(row);
     },
-    generateCellClasses({ column, cindex, rindex }) {
+    generateCellClasses({ column, cindex, row, rindex }) {
       let classes = "row ";
       classes += " cellPadding ";
       classes += _.camelCase(column.property);
@@ -1200,7 +1200,8 @@ export default {
         this.cellCssFunction !== null &&
         this.cellCssFunction instanceof Function
       ) {
-        classes += " " + this.cellCssFunction(column, cindex, rindex) + " ";
+        classes +=
+          " " + this.cellCssFunction(column, cindex, row, rindex) + " ";
       }
       classes += " " + this.cellClasses;
       return classes;

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -391,6 +391,10 @@ export default {
         return true;
       },
     },
+    cellCssFunction: {
+      type: Function,
+      default: null,
+    },
   },
   emits: {
     "update:selectedItem": null,
@@ -1192,6 +1196,12 @@ export default {
       classes += cindex % 2 === 0 ? " evenColumn" : " oddColumn";
       classes += rindex % 2 === 0 ? " evenRow" : " oddRow";
       classes += this.canCollapseDetailRows ? " bg-[#F9F8FA]" : "";
+      if (
+        this.cellCssFunction !== null &&
+        this.cellCssFunction instanceof Function
+      ) {
+        classes += " " + this.cellCssFunction(column, cindex, rindex) + " ";
+      }
       classes += " " + this.cellClasses;
       return classes;
     },


### PR DESCRIPTION
### What this does

Mehak needs a way to style the first row in table, this addresses that need in a general way. 

### Notes for the reviewer

To test:

- update revision in config.yml to "chore/add_first_and_last_row_css_classes_to_table"
- build and sync
- add ":cellCssFunction="(column, columnIndex, row, rowIndex) => { if (rowIndex === 0) return 'font-medium ' }" to a table
- verify that the first row is bold

### Missed anything?

- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] Security aspects considered? Unhappy paths?
- [ ] Have you accounted for accessibility?
- [ ] Commit messages and bodies explain what and why?

### More information

- [Slack thread](https://snyk.slack.com/archives/)
- [Jira ticket](https://snyksec.atlassian.net/browse/TEAM-0000)

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots, including URL if applicable, for any front end change. GIFs are most welcome!_
