### PR TITLE
Fix line smoothing & width

### DIFF
--- a/visualizations/frontend/charts/line_chart.html
+++ b/visualizations/frontend/charts/line_chart.html
@@ -29,7 +29,7 @@
                     {% endif %},
     
                     {% if config.line_width %}
-                    "shape": "{{ config.line_width }}"
+                    "width": "{{ config.line_width }}"
                     {% else %}
                     "width": 1.5
                     {% endif %}

--- a/visualizations/frontend/charts/line_chart.html
+++ b/visualizations/frontend/charts/line_chart.html
@@ -25,13 +25,13 @@
                     {% if config.line_smoothing %}
                     "smoothing": "{{ config.line_smoothing }}"
                     {% else %}
-                    "smoothing": 0.0
+                    "smoothing": 0.45
                     {% endif %},
     
                     {% if config.line_width %}
                     "shape": "{{ config.line_width }}"
                     {% else %}
-                    "width": 0.0
+                    "width": 1.5
                     {% endif %}
                 },
                 "connectgaps": true,


### PR DESCRIPTION
### What this does?

Fix the default values for line "smoothing": 0 & "width": 0 to line "smoothing": 0.45 & "width": 1.5.

### Notes for the reviewer

To test, this requires updates in both topcoat-public and topcoat-reports so check out in the 'fix/issue-summary-line-chart' topcoat-reports branch and run a build and sync modules.