### PR TITLE
Debounce table sorting

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -973,12 +973,15 @@ export default {
       }
 
       if (this.sort === "sql") {
-        this.setOrderByFilters();
-        this.fetchPagedLayer(false);
+        this.fetchLayerOnSort();
       } else {
         this.setupInternalRows();
       }
     },
+    fetchLayerOnSort: _.debounce(function () {
+      this.setOrderByFilters();
+      this.fetchPagedLayer(false);
+    }, 500),
     setOrderByFilters() {
       let sortedColumns = _.reverse(this.getSortedColumns());
       let orderByFilter = sortedColumns


### PR DESCRIPTION
### What this does

Currently if users want to sort a column in a table descending, then they have to wait for the it the data sorted ascending to come back before they can interact with the table again to sort descending. This adds a short debounce on the sorting data fetch so if users can quickly hit the sorting icon twice and not have to wait for an entire reload cycle.

I tested with a 250ms wait time and had issues clicking fast enough to get the second sort option, but no so fast that it just counted as a double click. 500 didn't cause a noticeable issue and was much easier to interact with. 

### Notes for the reviewer

- In config.yml update the revision from main to `chore/add_debounce_to_sorting` and run sync and build.
- open the issues details page and sort a column by quickly single clicking the sorting icon twice.
- Verify that the column is now sorted in descending order.

### Missed anything?

- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] Security aspects considered? Unhappy paths?
- [ ] Have you accounted for accessibility?
- [ ] Commit messages and bodies explain what and why?

### More information

- [Slack thread](https://snyk.slack.com/archives/C036C95BYG2/p1677867093548589)
- [Jira ticket](https://snyksec.atlassian.net/browse/DP-748)

### Screenshots / GIFs

Video of the problem:

https://user-images.githubusercontent.com/78518576/222807869-9c0e793f-5abc-4682-a10f-be6ba54daa37.mov


### After Merge

Give Ezra a heads up!


