### PR TITLE
feat: add onCellClick to TTable

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -199,6 +199,10 @@
               :ref="'rowCell_' + gindex + '_' + rindex + '_' + cindex"
               class="border-b border-[#D3D3D9] align-top py-[12px]"
               :class="generateCellClasses({ column, cindex, row, rindex })"
+              @click="
+                ($event) =>
+                  handleCellClick(getCellValue(row, column), row, column)
+              "
             >
               <slot
                 :name="column.property"
@@ -392,6 +396,10 @@ export default {
       },
     },
     cellCssFunction: {
+      type: Function,
+      default: null,
+    },
+    onCellClick: {
       type: Function,
       default: null,
     },
@@ -750,6 +758,16 @@ export default {
       this.updateStartIndex(0);
       if (this.pagerResetFunction) this.pagerResetFunction();
       this.fetchTotalRows();
+    },
+    handleCellClick(cellValue, row, column) {
+      if (this.onCellClick !== null && this.onCellClick instanceof Function) {
+        this.onCellClick({
+          cellValue,
+          row,
+          column,
+          table: this,
+        });
+      }
     },
     init() {
       // Error checking


### PR DESCRIPTION
### What this does

Used initially for Insights work, we will use this callback to post a message to the parent (AppUI Insights page), which will then display additional context to the user. Hopefully this is generic enough for some other use cases as well.

### Notes for the reviewer

Example usage:

If specified, reports can make use of this:

```jsx
<TTable
  :onCellClick="({cellValue, row, column, table}) => { /* I was clicked! */ }"
/>
```

### Missed anything?

- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] Security aspects considered? Unhappy paths?
- [ ] Have you accounted for accessibility?
- [ ] Commit messages and bodies explain what and why?

### More information

- [Slack thread](https://snyk.slack.com/archives/C036EMLCZL4/p1677842109853269)
- [Jira ticket](https://snyksec.atlassian.net/browse/INST-287)

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots, including URL if applicable, for any front end change. GIFs are most welcome!_
