### PR TITLE
Fix/no data without paging

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -757,7 +757,6 @@ export default {
       if (!validProps) return;
       if (!this.rows) return;
 
-      this.setInternalColumns();
       this.setupInternalRows();
 
       // Handle radio buttons setup
@@ -821,6 +820,8 @@ export default {
           detailRowOpen: !this.canCollapseDetailRows,
         };
       });
+
+      this.setInternalColumns();
       this.setDisplayRows();
       this.showSpinner = false;
     },
@@ -1232,7 +1233,9 @@ export default {
     },
     updateEndIndex(newEndIndex) {
       this.endIndex = newEndIndex;
-      if (!this.canPageServer) this.setupInternalRows();
+      if (!this.canPageServer) {
+        this.setupInternalRows();
+      }
     },
     fetchTotalRows() {
       const payload = this.createRequestPayload();


### PR DESCRIPTION
### What this does

The table is not displaying data when paging was disabled, this fixes that issue. It isn't the best approach, but it will be a non issue when we get to [this pitch](https://www.notion.so/snyk/026dbc50a0464ccb94e389bab033235a?v=6bbfc939d0e143a781412b203e550216&p=4d632e47f425409a9d4c0b917118faad&pm=s). 

### Notes for the reviewer

- Check out the  "feat/owasp-top-10" branch of topcoat-reports
- On the owasp_top_10_report page, update: 
`:canPageServer="true"`
to
`
:canPageServer="false"
:canPage="false"
`

- In config.yml update the revision from main to `fix/no_data_without_paging` and run sync and build.
- verify that the table shows 11 lines with no paging.


### Missed anything?

- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] Security aspects considered? Unhappy paths?
- [ ] Have you accounted for accessibility?
- [ ] Commit messages and bodies explain what and why?

### More information

- [Jira ticket](https://snyksec.atlassian.net/jira/software/c/projects/DP/issues/DP-750?jql=project%20%3D%20%22DP%22%20AND%20assignee%20%3D%20%226222996a6a4c4c0070af4496%22%20ORDER%20BY%20created%20DESC)

### Screenshots / GIFs

![Screen Shot 2023-03-06 at 5 14 23 PM](https://user-images.githubusercontent.com/78518576/223252708-cfe60d9e-698f-4a8f-a4c5-ff5546207071.png)

