### PR TITLE
Chore/add header icon slot to table

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -5,7 +5,7 @@
     <!-- Title -->
     <div v-if="showTableHeader" class="tableHeaderContainer">
       <div class="title">
-        <div class="titlePrefix"><slot name="titlePrefix"></slot></div>
+        <div class="title__prefix"><slot name="titlePrefix"></slot></div>
         <div v-if="title">{{ title }}</div>
         <t-tooltip v-if="tooltip" position="top" class="tooltip" width="260px">
           <help-circle-outline-icon slot="trigger" :size="16" />

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -5,6 +5,7 @@
     <!-- Title -->
     <div v-if="showTableHeader" class="tableHeaderContainer">
       <div class="title">
+        <div class="titlePrefix"><slot name="titlePrefix"></slot></div>
         <div v-if="title">{{ title }}</div>
         <t-tooltip v-if="tooltip" position="top" class="tooltip" width="260px">
           <help-circle-outline-icon slot="trigger" :size="16" />
@@ -1515,6 +1516,7 @@ highlighting a row on hover etc. */
   font-feature-settings: "tnum" on, "lnum" on;
   padding-top: 15px;
   padding-bottom: 15px;
+  gap: 10px;
 }
 
 .tooltip {


### PR DESCRIPTION
### What this does

The new ETC Analytics report needs an icon in front of the table title. 

### Notes for the reviewer

- update config.yml revision to:  chore/add_header_icon_slot_to_table
- Build and sync
- add `:<template v-slot:titlePrefix>
      <help-circle-outline-icon slot="trigger" :size="16" />
    </template>`
    to a table.
- Verify that the help circle icon shows up before the title.

### Missed anything?

- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] Security aspects considered? Unhappy paths?
- [ ] Have you accounted for accessibility?
- [ ] Commit messages and bodies explain what and why?


### Screenshots / GIFs

<img width="1907" alt="Screen Shot 2023-03-24 at 12 58 03 AM" src="https://user-images.githubusercontent.com/78518576/227428362-9c0fcdb8-edf6-4e5b-b023-ba499c6d981a.png">

