### PR TITLE
Update SnykPager.vue

### DIFF
--- a/library/components/tableComponents/SnykPager.vue
+++ b/library/components/tableComponents/SnykPager.vue
@@ -32,7 +32,7 @@
               >
                 <div
                   class="flex items-center justify-between w-full leading-[16.41px]"
-                  @click="$emit('updateItemsPerPage', itemsPerPageOption)"
+                  @click="updateItemsPerPage(itemsPerPageOption)"
                 >
                   <div
                     v-if="itemsPerPageOption === itemsPerPage"
@@ -95,8 +95,10 @@
       <div
         class="absolute right-2 top-5 font-normal text-[#727184] text-[13px] leading-[18px]"
       >
-        Showing {{ startIndex + 1 }}-
-        {{ Math.min(startIndex + itemsPerPage, numberOfItems) }}
+        Showing {{ (startIndex + 1).toLocaleString() }} -
+        {{
+          Math.min(startIndex + itemsPerPage, numberOfItems).toLocaleString()
+        }}
         of {{ numberOfItems.toLocaleString() }}
       </div>
     </div>
@@ -208,6 +210,10 @@ export default {
       if (internalPage < 1) return false;
       if (internalPage > this.lastPage) return false;
       return true;
+    },
+    updateItemsPerPage(itemsPerPageOption) {
+      this.reset();
+      this.$emit("updateItemsPerPage", itemsPerPageOption);
     },
   },
 };


### PR DESCRIPTION
### What this does

The SnykPager component was ending up in an invalid state when the # of pages was changed on the last page of data. This forces the selected page to go back to the first page.

Also noticed that the numbers in "showing x of y" were not being localized and went ahead and fixed that too.

### Notes for the reviewer

To test, update config.yml to point to "fix/updating_items_per_page_breaks_table_DP-885" instead of main. Run sync and build, then open issues detail and select the last page of data. Then update the # of rows per page and verify that when it loads it returns to the first page. 

### More information

- [Slack thread](https://snyk.slack.com/archives/C036EMLCZL4/p1680269427678529)
- [Jira ticket](https://snyksec.atlassian.net/jira/software/c/projects/DP/issues/DP-885)

### Screenshots / GIFs
The Problem:
Note that none of the pages are highlighted, the pages end with "..." instead of the last page, it says "Showing 15301- 3067 of 3,067" when last I checked, 15301 is more than 3,067, and that is actually the first page of data:

<img width="1413" alt="Screen Shot 2023-03-31 at 1 25 09 PM" src="https://user-images.githubusercontent.com/78518576/229188611-ea858bea-45fa-4987-940a-ca2bf24db079.png">

Solved: 

https://user-images.githubusercontent.com/78518576/229190096-d3a080cd-6c80-4634-b6b1-43e86a3a93d3.mov


