### PR TITLE
Feat/table head slot

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -59,7 +59,13 @@
       </div>
     </div>
 
-    <slot name="head"></slot>
+    <slot
+      name="head"
+      :total-count="totalRows"
+      :visible-count="internalRowsPerPage"
+      :start-index="startIndex"
+      :end-index="endIndex"
+    ></slot>
 
     <div
       v-if="isDataAvailable"

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -59,6 +59,8 @@
       </div>
     </div>
 
+    <slot name="head"></slot>
+
     <div
       v-if="isDataAvailable"
       id="tableContainer"


### PR DESCRIPTION
### What this does

Adds head slot for t-table, also adds table rows count data as slot parameters, works exactly like `footer` slot.

Why required?
Mehak is working on OWASP top 10 PDF page, which shows rows count at the top, so instead of re-counting same rows twice it's best to use the already counted data from table instead.

### Notes for the reviewer

Switch to this branch and use head slot code like this.
```
<div slot="head" slot-scope="slotProps">
    {{ slotProps.totalCount }}
</div>
```

### Missed anything?

- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] Security aspects considered? Unhappy paths?
- [ ] Have you accounted for accessibility?
- [ ] Commit messages and bodies explain what and why?

### More information

- [Slack thread](https://snyk.slack.com/archives/)
- [Jira ticket](https://snyksec.atlassian.net/browse/TEAM-0000)

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots, including URL if applicable, for any front end change. GIFs are most welcome!_
