### PR TITLE
fix: add border overwrite to line_chart

### DIFF
--- a/visualizations/frontend/charts/line_chart.html
+++ b/visualizations/frontend/charts/line_chart.html
@@ -544,3 +544,9 @@
         }
     }
 </figure>
+
+<style>
+    .vue--card--legacy {
+        box-shadow: none !important;
+    }
+</style>


### PR DESCRIPTION
### What this does

Workaround to remove borders from linecharts. The borderless property used in the past is not working anymore. This will be re-done in the near future.
More context here: https://snyk.slack.com/archives/C02L4EW3KJS/p1681980485066819

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, best to review commit-by-commit?, questions…_

### Missed anything?

- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] Security aspects considered? Unhappy paths?
- [ ] Have you accounted for accessibility?
- [ ] Commit messages and bodies explain what and why?

### More information

- [Slack thread](https://snyk.slack.com/archives/)
- [Jira ticket](https://snyksec.atlassian.net/browse/TEAM-0000)

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots, including URL if applicable, for any front end change. GIFs are most welcome!_
