### PR TITLE
tabs component

### DIFF
--- a/library/components/TTabs.vue
+++ b/library/components/TTabs.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="flex w-full" :class="!isVertical && 'flex-col'">
+    <div
+      class="flex items-center gap-2 bg-[#F9F8FA] px-4"
+      :class="isVertical && 'flex-col'"
+    >
+      <div
+        v-for="tab in tabs"
+        :key="tab"
+        class="cursor-pointer border-t-4"
+        :class="
+          activeTab === tab.slot
+            ? 'bg-white border-[#145DEB]'
+            : 'border-transparent'
+        "
+        @click="switchTab(tab)"
+      >
+        <slot :name="['tab_' + tab.slot]" :tab="tab">
+          {{ tab.label }}
+        </slot>
+      </div>
+    </div>
+    <slot v-if="activeTab" :name="activeTab"></slot>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    tabs: {
+      type: Array,
+      default: () => [],
+    },
+    isVertical: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data: () => ({
+    activeTab: null,
+    is_filter: true,
+  }),
+  methods: {
+    switchTab(tab) {
+      this.activeTab = tab.slot;
+      this.setFilterValue("tab", tab.slot);
+    },
+    onVisualizationInit() {
+      let value = this.getFilterValue("tab");
+      value = value && value !== "undefined" ? value : this.tabs[0].slot;
+      this.activeTab = value;
+    },
+  },
+};
+</script>

--- a/library/components/TTabs.vue
+++ b/library/components/TTabs.vue
@@ -1,9 +1,6 @@
 <template>
-  <div class="flex w-full" :class="!isVertical && 'flex-col'">
-    <div
-      class="flex items-center gap-2 bg-[#F9F8FA] px-6"
-      :class="isVertical && 'flex-col'"
-    >
+  <div class="flex flex-col w-full">
+    <div class="flex items-center gap-2 bg-[#F9F8FA] px-6">
       <div
         v-for="tab in tabs"
         :key="tab"
@@ -31,15 +28,16 @@ export default {
       type: Array,
       default: () => [],
     },
-    isVertical: {
-      type: Boolean,
-      default: false,
-    },
   },
   data: () => ({
     activeTab: null,
     is_filter: true,
   }),
+  mounted() {
+    if (!this.layer && this.tabs.length && !this.activeTab) {
+      this.switchTab(this.tabs[0]);
+    }
+  },
   methods: {
     switchTab(tab) {
       this.activeTab = tab.slot;

--- a/library/components/TTabs.vue
+++ b/library/components/TTabs.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex w-full" :class="!isVertical && 'flex-col'">
     <div
-      class="flex items-center gap-2 bg-[#F9F8FA] px-4"
+      class="flex items-center gap-2 bg-[#F9F8FA] px-6"
       :class="isVertical && 'flex-col'"
     >
       <div


### PR DESCRIPTION
**What's new**
A new tab component for pages.

**Why use this instead of Snyk's**
We need a tab component that can support visualizations inside it's tab buttons along with label, snyk does not support that.

**Snytax**
```
<t-tabs
    t-layer="tab_layer"
    t-filter:tab="my_tab_url_parameter"
    :tabs="[
        { label: "Tab one", slot: "section_1" }, 
        { label: "Tab two", slot: "section_2" }, 
    ]">
       
        // By default tab buttons populate themselves, but to make any changes,
        // their slot name can be used which prefixed with `tab_` so section_1 becomes `tab_section_one` 
        // Tabs
       <div slot="tab_section_one" slot-scope="{tab}">
           {{ tab.label }}
       </div>

        // Sections
        <div slot="section_1">
            Tab one section 
        </div>

        <div slot="section_2">
            Tab two section 
        </div>

</t-tabs>
```

Note: `t-layer` file can just be a blank SQL file, we just need it to bind URL param using t-filter:tab attribute.

[Figma](https://www.figma.com/file/SqlXbIgBD9mpYw6JG15aQc/Account-Analytics?node-id=2560-90786&t=2WQhCzXIoBIXelB8-0)

By default this component does not have much of a design, but is entirely customizable using slots, figma is just used as a sample for functionality.