### PR TITLE
re-render plotly on pagination change

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -142,7 +142,11 @@
       </div>
 
       <!-- Data Rows -->
-      <div v-else class="makeGridIgnoreDiv tableDataContainer">
+      <div
+        v-else
+        :key="tableDataKey"
+        class="makeGridIgnoreDiv tableDataContainer"
+      >
         <div
           v-for="(group, gindex) in internalGroups"
           :key="gindex"
@@ -446,6 +450,7 @@ export default {
       additionalFilters: {},
       internalColumns: [],
       modifiableColumnsFilter: null,
+      tableDataKey: 0,
     };
   },
   computed: {
@@ -1292,6 +1297,8 @@ export default {
           this.setInternalColumns(setColumnSort);
           this.setupInternalRows();
         }
+        this.tableDataKey = Math.random() * this.startIndex;
+        // For plotly: Any type of random key can force reload the data div on page, resulting in plotly to re-adjust itself.
       });
     },
     createRequestPayload() {


### PR DESCRIPTION
**Problem**
Plotly, when used inside tables does not reload with pagination, it always shows the result of first page.

**What's fixed**
Vue re-renders any div element if a `key` value is changed, which results in plotly re-adjusting itself to show new data.

**How to test**
1. Open https://snyk-insights.topcoatdata.app/reporting/a/develop.
2. Switch branch to `feat/enterprise_reporting`
3. Go to Analytics Page: https://snyk-insights.topcoatdata.app/reporting/analytics
4. There are a bunch of tables on this page along with tiny plotly charts used inside their rows.
5. Change pages of any table, plotly charts should change and not stay static.


**Before**
https://github.com/topcoat-data/topcoat-public/assets/43262405/3acea3bd-784f-4567-853b-80c871051715

**After**
https://github.com/topcoat-data/topcoat-public/assets/43262405/94144435-4139-4b71-97d8-954d3b54c287


