### PR TITLE
add onFiltersUpdated to TMultiSelector

### DIFF
--- a/visualizations/frontend/filters/v2/TMultiSelector.vue
+++ b/visualizations/frontend/filters/v2/TMultiSelector.vue
@@ -333,6 +333,13 @@ export default {
       this.checked = this.checked.filter((c) => c !== id);
       this.updateUrlParam();
     },
+    onFiltersUpdated() {
+      if (this.getFilterValue("selected_items")) {
+        this.onVisualizationInit();
+      } else {
+        this.reset();
+      }
+    },
   },
 };
 </script>

--- a/visualizations/frontend/filters/v2/TMultiSelector.vue
+++ b/visualizations/frontend/filters/v2/TMultiSelector.vue
@@ -280,6 +280,8 @@ export default {
     onVisualizationInit() {
       const initial_value = this.getFilterValue("selected_items");
 
+      this.checked = [];
+
       if (initial_value) {
         this.checked = initial_value.split("|");
       } else if (this.defaultValue) {
@@ -334,11 +336,7 @@ export default {
       this.updateUrlParam();
     },
     onFiltersUpdated() {
-      if (this.getFilterValue("selected_items")) {
-        this.onVisualizationInit();
-      } else {
-        this.reset();
-      }
+      this.onVisualizationInit();
     },
   },
 };


### PR DESCRIPTION
### What this does

Allowing this component to react to changes to the filter value made from outside.

If there is a filter value set, then re-run the visualisation init. Also clears the checked array on init in case the new filter value is empty.

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, best to review commit-by-commit?, questions…_

### Missed anything?

- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] Security aspects considered? Unhappy paths?
- [ ] Have you accounted for accessibility?
- [ ] Commit messages and bodies explain what and why?

### More information

- [Slack thread](https://snyk.slack.com/archives/)
- [Jira ticket](https://snyksec.atlassian.net/browse/TEAM-0000)

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots, including URL if applicable, for any front end change. GIFs are most welcome!_
