### PR TITLE
fix: start loading immediately

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -1003,6 +1003,7 @@ export default {
         .join(" ");
     },
     updateSort(column) {
+      this.showSpinner = true;
       const sortPriorities = this.internalColumns
         .filter((c) => c.sort)
         .map((c) => c.sort.priority);
@@ -1315,7 +1316,6 @@ export default {
       this.setLayerFilter("limit", "" + this.internalRowsPerPage);
       this.setLayerFilter("offset", "" + this.startIndex);
       const payload = this.createRequestPayload();
-      this.showSpinner = true;
       this.$store.dispatch("layers/fetchPagedLayer", payload).then(() => {
         if (!this.isDataAvailable) {
           this.init();


### PR DESCRIPTION
### What this does

Users are confused when the table doesn't go into a loading state immediately after clicking the 'sort'. They get the imnpression nothing is happening. This PR puts the table into the loading state immediately, by moving the state change out of the debounced function. The network request is still debounced.

### Notes for the reviewer

To test this fix...

Go to https://snyk-insights.topcoatdata.app/
Change the branch in `config.yml` that points to topcoat-public to the branch name of this PR,as below:
```
modules:
    - git: https://github.com/topcoat-data/topcoat-public.git
      revision: fix/sort-loading-state
```
Save the config.yml file, and click the 'Build and Sync modules' button (it's a cloud symbol)
<img width="1500" alt="Screenshot 2023-06-02 at 17 28 12" src="https://github.com/topcoat-data/topcoat-public/assets/1307818/6ccd1be7-45fb-4429-b1ae-e9f0b478e1cf">
Refresh the reports in https://snyk-insights.topcoatdata.app/

Test the table column sort works. Make sure the repeatedly clicking still results in a debounce of requests. Report anything that looks like it is not working properly.


### More information

- [Linear ticket FP-816](https://linear.app/snyk/issue/FP-816/start-loading-table-immediately)

### Screenshots / GIFs

#### Before
![2023-05-31 18 34 39](https://github.com/topcoat-data/topcoat-public/assets/1307818/527c1ee4-9c02-40e7-aff4-555313d0b6eb)

#### After
![2023-05-31 18 38 16](https://github.com/topcoat-data/topcoat-public/assets/1307818/45ba57cb-f968-45fd-bcde-dddf3c6363ab)

