### PR TITLE
fix: make entire column header trigger sort

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -100,7 +100,7 @@
           v-for="(column, index) in internalColumns"
           :key="column.header"
           :ref="'headerCell_' + index"
-          class="headerCell cellPadding focus:outline-none focus-visible:ring flex align-center"
+          class="cellPadding focus:outline-none focus-visible:ring flex align-center"
           :class="generateHeaderClasses(column.property, index)"
           @click="updateSort(column)"
         >
@@ -1518,11 +1518,6 @@ state, for example  */
   background-color: var(--page-background-color);
 }
 
-.headerCell {
-  font-weight: 700;
-  font-size: 1.2em;
-}
-
 .row.groupHeader {
   text-align: left;
   font-size: 1.1em;
@@ -1544,7 +1539,6 @@ highlighting a row on hover etc. */
   padding-bottom: 12px;
 }
 
-.headerCell,
 .row {
   margin: 0px 0;
 }

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -94,13 +94,11 @@
           :indeterminate.prop="someChecked"
         />
         <!-- Headings -->
-        <!-- header div; padding -->
-        <!-- content div; padding -->
         <button
           v-for="(column, index) in internalColumns"
           :key="column.header"
           :ref="'headerCell_' + index"
-          class="cellPadding focus:outline-none focus-visible:ring flex align-center"
+          class="cellPadding border-b border-[#D3D3D9] focus:outline-none focus-visible:ring flex align-center leading-[15px] text-[12px] text-[#555463] font-semibold tracking-[0.12em] uppercase"
           :class="generateHeaderClasses(column.property, index)"
           @click="updateSort(column)"
         >
@@ -375,12 +373,6 @@ export default {
       default() {
         return {};
       },
-    },
-    // Do we need this? Can we get rid of it?
-    headerClasses: {
-      type: String,
-      default:
-        "border-b border-[#D3D3D9] text-[12px] text-[#555463] font-semibold leading-[15px] tracking-[0.12em] uppercase",
     },
     cellClasses: {
       type: String,
@@ -1094,7 +1086,6 @@ export default {
       let classes = _.camelCase(header);
       classes += " " + _.camelCase("header " + header);
       classes += index % 2 === 0 ? " evenColumn" : " oddColumn";
-      classes += " " + this.headerClasses;
       if (this.isHeaderFixed) classes += " isHeaderFixed";
       return classes;
     },

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -96,48 +96,41 @@
         <!-- Headings -->
         <!-- header div; padding -->
         <!-- content div; padding -->
-        <div
+        <button
           v-for="(column, index) in internalColumns"
           :key="column.header"
           :ref="'headerCell_' + index"
-          class="headerCell cellPadding"
+          class="headerCell cellPadding focus:outline-none focus-visible:ring flex align-center"
           :class="generateHeaderClasses(column.property, index)"
+          @click="updateSort(column)"
         >
-          <button
-            class="focus:outline-none focus-visible:ring flex align-center"
+          <slot
+            :name="generateSlotName('header', column.header)"
+            v-bind="column"
           >
+            {{ column.header }}
+          </slot>
+
+          <span v-if="column.sort" class="sortIcon">
             <slot
-              :name="generateSlotName('header', column.header)"
+              v-if="column.sort.direction === 'ASC'"
+              name="sortAscendingIcon"
               v-bind="column"
             >
-              {{ column.header }}
+              <menu-up-icon :size="20" />
             </slot>
-
-            <span
-              v-if="column.sort"
-              class="sortIcon focus:outline-none focus-visible:ring"
-              @click="updateSort(column)"
+            <slot
+              v-else-if="column.sort.direction === 'DESC'"
+              name="sortDescendingIcon"
+              v-bind="column"
             >
-              <slot
-                v-if="column.sort.direction === 'ASC'"
-                name="sortAscendingIcon"
-                v-bind="column"
-              >
-                <menu-up-icon :size="20" />
-              </slot>
-              <slot
-                v-else-if="column.sort.direction === 'DESC'"
-                name="sortDescendingIcon"
-                v-bind="column"
-              >
-                <menu-down-icon :size="20" />
-              </slot>
-              <slot v-else name="sortUnsortedIcon" v-bind="column">
-                <menu-swap-icon :size="20" class="unsortedIcon" />
-              </slot>
-            </span>
-          </button>
-        </div>
+              <menu-down-icon :size="20" />
+            </slot>
+            <slot v-else name="sortUnsortedIcon" v-bind="column">
+              <menu-swap-icon :size="20" class="unsortedIcon" />
+            </slot>
+          </span>
+        </button>
 
         <!-- No table data -->
         <div

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -380,7 +380,7 @@ export default {
     headerClasses: {
       type: String,
       default:
-        "py-2 border-b border-[#D3D3D9] text-[12px] text-[#555463] font-semibold leading-[15px] tracking-[0.12em] uppercase",
+        "border-b border-[#D3D3D9] text-[12px] text-[#555463] font-semibold leading-[15px] tracking-[0.12em] uppercase",
     },
     cellClasses: {
       type: String,

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -98,7 +98,7 @@
           v-for="(column, index) in internalColumns"
           :key="column.header"
           :ref="'headerCell_' + index"
-          class="cellPadding border-b border-[#D3D3D9] focus:outline-none focus-visible:ring flex align-center leading-[15px] text-[12px] text-[#555463] font-semibold tracking-[0.12em] uppercase"
+          class="cellPadding border-b border-[#D3D3D9] focus:outline-none focus-visible:ring flex items-center leading-[15px] text-[12px] text-[#555463] font-semibold tracking-[0.12em] uppercase"
           :class="generateHeaderClasses(column.property, index)"
           @click="updateSort(column)"
         >

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -103,7 +103,9 @@
           class="headerCell cellPadding"
           :class="generateHeaderClasses(column.property, index)"
         >
-          <div style="display: flex; align-items: center">
+          <button
+            class="focus:outline-none focus-visible:ring flex align-center"
+          >
             <slot
               :name="generateSlotName('header', column.header)"
               v-bind="column"
@@ -111,7 +113,7 @@
               {{ column.header }}
             </slot>
 
-            <button
+            <span
               v-if="column.sort"
               class="sortIcon focus:outline-none focus-visible:ring"
               @click="updateSort(column)"
@@ -133,8 +135,8 @@
               <slot v-else name="sortUnsortedIcon" v-bind="column">
                 <menu-swap-icon :size="20" class="unsortedIcon" />
               </slot>
-            </button>
-          </div>
+            </span>
+          </button>
         </div>
 
         <!-- No table data -->


### PR DESCRIPTION
### What this does

This address a customer ask, that Ezra brought to the Frontend Platform team: https://snyk.slack.com/archives/C02L4EW3KJS/p1685517193204489

1. Makes entire column header clickable for triggering sort
2. removes `headerClasses` prop; did not seem to be used anywhere, and was not documented here: https://docs.google.com/document/d/1pwyyc1OtS6jUoOb3xNkFRFxPgnqJQFtmmptmtQ3D358/edit#

### Notes for the reviewer

Go to https://snyk-insights.topcoatdata.app/
Change the branch in `config.yml` that points to topcoat-public to the branch name of this PR,as below:
```
modules:
    - git: https://github.com/topcoat-data/topcoat-public.git
      revision: fix/sort-column-header-clickability
```
Save the config.yml file, and click the 'Build and Sync modules' button (it's a cloud symbol)
<img width="1500" alt="Screenshot 2023-06-02 at 17 28 12" src="https://github.com/topcoat-data/topcoat-public/assets/1307818/6ccd1be7-45fb-4429-b1ae-e9f0b478e1cf">
Refresh the reports in https://snyk-insights.topcoatdata.app/

Test the table column sort and ensure it still works as expected. Make sure the entire header area is clickable.

### More information

- [Linear ticket /FP-817](https://linear.app/snyk/issue/FP-817/make-entire-column-header-clickable-for-the-sort)

### Screenshots / GIFs
There are minimal changes from what one can see, but the padding has also been correct, so the table should look closer to the [designs](https://www.figma.com/file/IaywW74sLSgYJSYHjOC0ZL/branch/a5uu0aqVYT8kzKdZKUM6pa/Reporting?type=design&node-id=1-2&t=584Ugjop49CoKMo6-0) than before
![After-entire-header-clickable](https://github.com/topcoat-data/topcoat-public/assets/1307818/33372858-ea91-4708-8ff0-1b6a1c5e0052)


![Before-only-sort-icon-clickable](https://github.com/topcoat-data/topcoat-public/assets/1307818/1253155a-e85e-469b-a2d7-47e7726659f1)

