### PR TITLE
Feat/pdf table component

### DIFF
--- a/visualizations/frontend/other/TPdfTable.vue
+++ b/visualizations/frontend/other/TPdfTable.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="relative overflow-auto">
+    <t-loading-spinner v-if="loading" position="relative" />
+    <slot name="header" :loading="loading"></slot>
+    <table class="w-full table-fixed" :class="tableClasses">
+      <thead>
+        <th v-for="column in columns" :key="column">
+          <slot :name="'col-' + column" :column="column">
+            {{ column }}
+          </slot>
+        </th>
+      </thead>
+      <tbody>
+        <tr v-for="(row, index) in rows" :key="'row-' + index">
+          <td v-for="column in columns" :key="column" class="break-all">
+            <slot :name="'row-' + column" :row="row">
+              {{ row[column] ? row[column].rendered : "" }}
+            </slot>
+          </td>
+        </tr>
+      </tbody>
+      <div v-if="!loading && !rows.length" class="text-center">No Data</div>
+    </table>
+    <slot
+      name="footer"
+      :rows-limit="rowsLimit"
+      :rows-total="rowsTotal"
+      :loading="loading"
+    >
+      <div v-if="rowsTotal > rowsLimit" class="pt-4 text-right">
+        Showing {{ rowsLimit }} of {{ rowsTotal }}
+      </div>
+    </slot>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    hiddenColumns: {
+      type: Array,
+      default: () => [],
+    },
+    dynamicColumns: {
+      type: Array,
+      default: () => [],
+    },
+    customColumns: {
+      type: Array,
+      default: () => [],
+    },
+    rowsLimit: {
+      type: Number,
+      default: 5,
+    },
+    tableClasses: {
+      type: String,
+      default: "",
+    },
+  },
+  data: () => ({
+    is_filter: true,
+    rowsTotal: 0,
+  }),
+  created() {
+    this.fetchOnMounted = false;
+  },
+  computed: {
+    columns() {
+      const columns = this.rows.length ? Object.keys(this.rows[0]) : [];
+      const filteredInternalColumns = columns.filter(
+        (col) => !this.hiddenColumns.includes(col)
+      );
+      return [...filteredInternalColumns, ...this.customColumns];
+    },
+    visibleLayerColumns() {
+      let columns = [];
+      for (let column of this.dynamicColumns) {
+        if (this.filteredColumns.includes(column.url_value)) {
+          columns.push(column.sql_value);
+        }
+      }
+      return columns;
+    },
+    filteredColumns() {
+      const layerColumnsFilterName = `${this.layer}_cols`;
+      const urlParam =
+        this.filters.filter((f) =>
+          f.name.includes(layerColumnsFilterName)
+        )[0] || {};
+      return urlParam.value ? urlParam.value.split("|") : [];
+    },
+  },
+  mounted() {
+    this.prepareFilters();
+    this.fetchLayerData();
+    this.fetchRowsCount();
+  },
+  methods: {
+    prepareFilters() {
+      this.setLayerFilter("limit", this.rowsLimit);
+      this.setLayerFilter("offset", 0); // Always showing first page on PDF, pagination not required there.
+      this.setLayerFilter("orderBy", this.getFilterState(`${this.layer}_sort`));
+      this.setLayerFilter(
+        "column_list",
+        JSON.stringify(this.visibleLayerColumns)
+      );
+    },
+    fetchRowsCount() {
+      this.$store
+        .dispatch("layers/fetchLayerCount", this.createRequestPayload())
+        .then((rowsTotal) => {
+          this.rowsTotal = rowsTotal;
+        });
+    },
+    createRequestPayload() {
+      return {
+        render: {
+          visualization: this.tag,
+        },
+        target: this.tag_unique,
+        layer: this.layer,
+      };
+    },
+    setLayerFilter(filterName, filterValue) {
+      const table = this.$store.state.layers.components[this.tag_unique];
+      if (!table.filters) {
+        table.filters = {};
+      }
+      window.Vue.set(table.filters, filterName, filterValue);
+    },
+  },
+};
+</script>

--- a/visualizations/frontend/other/TPdfTable.vue
+++ b/visualizations/frontend/other/TPdfTable.vue
@@ -2,9 +2,9 @@
   <div class="relative overflow-auto">
     <t-loading-spinner v-if="loading" position="relative" />
     <slot name="header" :loading="loading"></slot>
-    <table class="w-full table-fixed" :class="tableClasses">
+    <table class="w-full table-fixed" :class="containerClass">
       <thead>
-        <th v-for="column in columns" :key="column">
+        <th v-for="column in columns" :key="column" :class="columnsClass">
           <slot :name="'col-' + column" :column="column">
             {{ column }}
           </slot>
@@ -12,7 +12,12 @@
       </thead>
       <tbody>
         <tr v-for="(row, index) in rows" :key="'row-' + index">
-          <td v-for="column in columns" :key="column" class="break-all">
+          <td
+            v-for="column in columns"
+            :key="column"
+            class="break-all"
+            :class="rowsClass"
+          >
             <slot :name="'row-' + column" :row="row">
               {{ row[column] ? row[column].rendered : "" }}
             </slot>
@@ -27,7 +32,7 @@
       :rows-total="rowsTotal"
       :loading="loading"
     >
-      <div v-if="rowsTotal > rowsLimit" class="pt-4 text-right">
+      <div class="pt-4 text-right">
         Showing {{ rowsLimit }} of {{ rowsTotal }}
       </div>
     </slot>
@@ -53,7 +58,15 @@ export default {
       type: Number,
       default: 5,
     },
-    tableClasses: {
+    containerClass: {
+      type: String,
+      default: "",
+    },
+    columnsClass: {
+      type: String,
+      default: "",
+    },
+    rowsClass: {
       type: String,
       default: "",
     },
@@ -62,9 +75,6 @@ export default {
     is_filter: true,
     rowsTotal: 0,
   }),
-  created() {
-    this.fetchOnMounted = false;
-  },
   computed: {
     columns() {
       const columns = this.rows.length ? Object.keys(this.rows[0]) : [];
@@ -90,6 +100,9 @@ export default {
         )[0] || {};
       return urlParam.value ? urlParam.value.split("|") : [];
     },
+  },
+  created() {
+    this.fetchOnMounted = false;
   },
   mounted() {
     this.prepareFilters();


### PR DESCRIPTION
A lightweight table component for PDF pages.

Syntax
```
<t-pdf-table t-layer="table_layer">
  
   // Columns
   <div slot="col-[COLUMN_NAME_1]" slot-scope="{ column }">
        {{ column }}
   </div>

   // Rows
   <div slot="row-[COLUMN_NAME_1]" slot-scope="{ row }">
       {{ row[COLUMN_NAME_1].rendered }}
   </div>

</t-pdf-table>
```

**Columns**
- To modify columns from slots, exposed slots can be used, that are named after their column with a prefix of `col-`.
- Column slots also expose the column name in slot prop `column`.

**Rows**
- Rows can also be modified exactly like column but instead of `col-` prefix, `row-` prefix can be used.
- Rows also have exposed `row` object to be used in slots.

**Props**
- `hiddenColumns[]`: Takes column names inside an array to hide them from table.
    Example: `['COL_1', 'COL_2']`.

- `dynamicColumns[]`: Takes array of objects to hide and show columns depending on URL parameters.
    - url_value: The column name that is associated with URL parameters.
    - sql_value: The column name that is associated with SQL layer.

    Example: In original table this prop was called `modifiableColumns`.
    ```
    [
        { url_value: 'SCORE', sql_value: 'SCORE' },
        { url_value: 'EXPLOIT MATURITY', sql_value: 'EXPLOIT_MATURITY' },
    ]
    ```

- `customColumns[]`: Not layer custom columns, takes columns name in an array, they still support `row` object to bind any data with them and are exposed using slot name exactly like other columns.
    Example: ['CUSTOM_COL_1', 'CUSTOM_COL_2']

- `rowsLimit`: Limits the number of rows to load, shows 5 by default.

- `containerClass`: Binds classes with `<table />` html tag.
- `columnClass`: Binds classes with `<th />` html tag.
- `rowsClass`: Binds classes with `<td />` html tag.

**Slots**
- `col-[COLUMN_NAME]`: Exposes any column by it's name with a `col-` prefix.
- `row-[COLUMN_NAME]`: Exposes any column by it's name with a `row-` prefix.
- `header`: Header of table, this is right before `<table />` tag starts, empty by default.
- `footer`: Footer of table, this is right after `<table />` tag ends, shows number of visible rows by default if total rows > visible rows.


![Screenshot 2023-06-12 at 12 23 12 PM](https://github.com/topcoat-data/topcoat-public/assets/43262405/9fa54bde-eed6-433c-8098-eb874d7ff0e7)

