### PR TITLE
fix: reinstate headerClasses prop

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -374,6 +374,11 @@ export default {
         return {};
       },
     },
+    headerClasses: {
+      type: String,
+      default:
+        "border-b border-[#D3D3D9] text-[12px] text-[#555463] font-semibold leading-[15px] tracking-[0.12em] uppercase",
+    },
     cellClasses: {
       type: String,
       default: "break-all",


### PR DESCRIPTION
### What this does

This is still used by the collapsable rows functionality.

### Notes for the reviewer

On a table that has the `canCollapseDetailRows` prop.

### Missed anything?

- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] Security aspects considered? Unhappy paths?
- [ ] Have you accounted for accessibility?
- [ ] Commit messages and bodies explain what and why?

### More information

- [Slack thread](https://snyk.slack.com/archives/C036EMLCZL4/p1686749109465319)
- [Jira ticket](https://snyksec.atlassian.net/browse/TEAM-0000)

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots, including URL if applicable, for any front end change. GIFs are most welcome!_
