### PR TITLE
fix: remove reference to headerClasses prop

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -82,7 +82,7 @@
         :style="columnWidthsStyle"
       >
         <!-- Empty div to keep the headers lined up with their columns when there are exapnd/collapse buttons  -->
-        <div v-if="canCollapseDetailRows" :class="headerClasses"></div>
+        <div v-if="canCollapseDetailRows"></div>
         <!-- Empty div to keep the headers lined up with their columns when there are radio buttons  -->
         <div v-if="showRadioButtons"></div>
         <!-- Toggle all of the check boxes  -->


### PR DESCRIPTION
### What this does

@benbarnett picked up on an error with the TTable that was created with the removal of `headerClasses` in #239. See screenshots for the error

### Notes for the reviewer

Go to https://snyk-insights.topcoatdata.app/
Change the branch in `config.yml` that points to topcoat-public to the branch name of this PR,as below:
```
modules:
    - git: https://github.com/topcoat-data/topcoat-public.git
      revision: fix/headClasses-prop-still-being-referenced
```
Save the config.yml file, and click the 'Build and Sync modules' button (it's a cloud symbol)
<img width="1500" alt="Screenshot 2023-06-02 at 17 28 12" src="https://github.com/topcoat-data/topcoat-public/assets/1307818/6ccd1be7-45fb-4429-b1ae-e9f0b478e1cf">
Refresh the reports in https://snyk-insights.topcoatdata.app/

Test the table on Vulnerabilities Detail Report. Make sure it displays and each section you open is also displaying.

### More information

- [Slack thread](https://snyk.slack.com/archives/C036EMLCZL4/p1686749109465319)


### Screenshots / GIFs

#### Before
<img width="1613" alt="Screenshot 2023-06-14 at 16 02 05" src="https://github.com/topcoat-data/topcoat-public/assets/1307818/e779cd0c-22e2-464f-ae02-1feb1d72b9a7">

#### After
<img width="1613" alt="Screenshot 2023-06-14 at 15 58 27" src="https://github.com/topcoat-data/topcoat-public/assets/1307818/189e7be1-94d3-4eda-b60f-707c5136a5ce">

