### PR TITLE
feat: add prop for set custom height on TTable

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="rootTableContainer" :class="{ makeTooltipVisible: tooltip }">
+  <div class="rootTableContainer" :class="{ makeTooltipVisible: tooltip }" :style="{height: computedHeight}">
     <slot name="columnConfig" :set-column-config="setColumnConfig"></slot>
 
     <!-- Title -->
@@ -256,7 +256,7 @@
       </div>
       <!-- Pagination  -->
       <div
-        v-if="!isPdf && totalRows > internalRowsPerPage"
+        v-if="!isPdf && totalRows > internalRowsPerPage && isDataAvailable"
         class="border-t border-[#D3D3D9]"
       >
         <SnykPager
@@ -293,6 +293,10 @@ export default {
       default: false,
     },
     title: {
+      type: String,
+      default: "",
+    },
+    height: {
       type: String,
       default: "",
     },
@@ -465,6 +469,9 @@ export default {
     };
   },
   computed: {
+    computedHeight() {
+      return this.height && !this.isDataAvailable ? `${this.height}px` : "auto";
+    },
     isPdf() {
       return window.location.href.includes("/pdf?");
     },
@@ -1313,6 +1320,7 @@ export default {
         });
     },
     fetchPagedLayer(setColumnSort = true) {
+      this.showSpinner = true;
       this.setLayerFilter("limit", "" + this.internalRowsPerPage);
       this.setLayerFilter("offset", "" + this.startIndex);
       const payload = this.createRequestPayload();


### PR DESCRIPTION
### What this does

Improves the TTable loading UX.
Addition:
- New prop: `height`. This will avoid the table jumps between no-data => data transitions.
- Pagination: the pagination component is not rendered until we have fetched the rows data.

### Notes for the reviewer
On snyk-insights:
Use this module revision: `revision: feat/table-height`
Add some height to a table, for example in the issues-detail page, you can add a new prop to the table:
```js
        <TTable 
            height="993"
              ...
```


### More information
https://linear.app/snyk/issue/FP-913/topcoat-ttable-component-improvements

### Screenshots / GIFs

Before:

https://github.com/topcoat-data/topcoat-public/assets/1915140/79ca93c3-2026-44df-9bde-dafbe488f2dc

After:

https://github.com/topcoat-data/topcoat-public/assets/1915140/09a9566d-31cb-430a-a004-0583344a8554



