### PR TITLE
fix: only add grid columns if collapsable has rows

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="rootTableContainer" :class="{ makeTooltipVisible: tooltip }" :style="{height: computedHeight}">
+  <div
+    class="rootTableContainer"
+    :class="{ makeTooltipVisible: tooltip }"
+    :style="{ height: computedHeight }"
+  >
     <slot name="columnConfig" :set-column-config="setColumnConfig"></slot>
 
     <!-- Title -->
@@ -141,6 +145,9 @@
           "
           class="spanAllColumns center_cell"
         >
+          <!-- Empty div to keep the headers lined up with their columns when there are exapnd/collapse buttons  -->
+          <div v-if="canCollapseDetailRows"></div>
+
           <slot name="no_data">
             <div><i class="i-fa-solid i-fa-inbox"></i></div>
             <div>{{ noDataMessage }}</div>
@@ -501,11 +508,7 @@ export default {
         if (this.showCheckboxes) {
           columnsWidths += " 2em";
         }
-        if (
-          this.canCollapseDetailRows &&
-          this.internalRows?.length > 0 &&
-          this.displayRows?.length > 0
-        ) {
+        if (this.canCollapseDetailRows) {
           columnsWidths += " 2em";
         }
 

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -510,6 +510,12 @@ export default {
         }
         if (this.canCollapseDetailRows) {
           columnsWidths += " 2em";
+
+          if (
+            !(this.internalRows?.length > 0 && this.displayRows?.length > 0)
+          ) {
+            columnsWidths += "auto";
+          }
         }
 
         this.internalColumns.forEach((column) => {

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -493,11 +493,7 @@ export default {
       );
     },
     columnWidthsStyle() {
-      if (
-        Array.isArray(this.internalColumns) &&
-        this.internalRows?.length > 0 &&
-        this.displayRows?.length > 0
-      ) {
+      if (Array.isArray(this.internalColumns)) {
         let columnsWidths = "grid-template-columns:";
         if (this.showRadioButtons) {
           columnsWidths += " 2em";
@@ -505,7 +501,11 @@ export default {
         if (this.showCheckboxes) {
           columnsWidths += " 2em";
         }
-        if (this.canCollapseDetailRows) {
+        if (
+          this.canCollapseDetailRows &&
+          this.internalRows?.length > 0 &&
+          this.displayRows?.length > 0
+        ) {
           columnsWidths += " 2em";
         }
 

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -514,7 +514,7 @@ export default {
           if (
             !(this.internalRows?.length > 0 && this.displayRows?.length > 0)
           ) {
-            columnsWidths += "auto";
+            columnsWidths += " auto";
           }
         }
 


### PR DESCRIPTION
### What this does

Following on from #248, there was another edge case where if the table initially loads data, and then some combination of applied filters means that the table returns no results -- then the template columns were required again.

I've tested this with:
- **standard** tables that have initial data (and then applied a filter to produce an empty table again)
  - this is the one that required this fix
- **standard** tables that have no initial data
  - rendered as expected and as before
- **collapsable** tables that have initial data (and then applied a filter to produce an empty table again)
  - rendered as expected and as before
- **collapsable** tables that have no initial data
  - rendered as expected and as before

Screenshots for the states that had the layout issue shown below;

**Before (in `main`):**
![Screenshot 2023-06-20 at 10 19 46](https://github.com/topcoat-data/topcoat-public/assets/295469/1c075747-9324-4d43-b96a-dce343034e47)


**With this fix:**
![Screenshot 2023-06-20 at 10 18 42](https://github.com/topcoat-data/topcoat-public/assets/295469/e2c8a9bf-8e9e-4e95-968f-fd1dbb29c494)


### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, best to review commit-by-commit?, questions…_

### Missed anything?

- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] Security aspects considered? Unhappy paths?
- [ ] Have you accounted for accessibility?
- [ ] Commit messages and bodies explain what and why?

### More information

- [Slack thread](https://snyk.slack.com/archives/)
- [Jira ticket](https://snyksec.atlassian.net/browse/TEAM-0000)

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots, including URL if applicable, for any front end change. GIFs are most welcome!_
