### PR TITLE
fix: Rename height prop to defaultHeight

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -296,7 +296,7 @@ export default {
       type: String,
       default: "",
     },
-    height: {
+    defaultHeight: {
       type: String,
       default: "",
     },
@@ -470,7 +470,7 @@ export default {
   },
   computed: {
     computedHeight() {
-      return this.height && !this.isDataAvailable ? `${this.height}px` : "auto";
+      return this.defaultHeight && !this.isDataAvailable ? `${this.defaultHeight}px` : "auto";
     },
     isPdf() {
       return window.location.href.includes("/pdf?");


### PR DESCRIPTION
### What this does

`hight` was producing a collision with all the wrappers that topcoat-core adds automagically:
outerdiv, visualizationWrapper, etc.
So I had to rename the prop to defaultHeight instead.

