### PR TITLE
expose tr tags with slots in pdf table

### DIFF
--- a/visualizations/frontend/other/TPdfTable.vue
+++ b/visualizations/frontend/other/TPdfTable.vue
@@ -12,18 +12,27 @@
           </th>
         </thead>
         <tbody>
-          <tr v-for="(row, index) in rows" :key="'row-' + index">
-            <td
-              v-for="column in columns"
-              :key="column"
-              class="break-all"
-              :class="rowsClass"
-            >
-              <slot :name="'row-' + column" :row="row">
-                {{ row[column] ? row[column].rendered : "" }}
-              </slot>
-            </td>
-          </tr>
+          <!-- Table rows are exposed using row-INDEX for slot name, can be used to target specific row by index. -->
+          <slot
+            v-for="(row, index) in rows"
+            :key="'row-' + index"
+            :name="'row-' + index"
+            :row="row"
+            :columns="columns"
+          >
+            <tr>
+              <td
+                v-for="column in columns"
+                :key="column"
+                class="break-all"
+                :class="rowsClass"
+              >
+                <slot :name="'row-' + column" :row="row">
+                  {{ row[column] ? row[column].rendered : "" }}
+                </slot>
+              </td>
+            </tr>
+          </slot>
         </tbody>
         <div v-if="!loading && !rows.length" class="text-center">No Data</div>
       </table>


### PR DESCRIPTION
In some cases, specific rows need to be customised from page, in that case this PR will expose `tr` tag to customise it from page file.

Will not affect current state of rows until exposed.