### PR TITLE
prop to override value label

### DIFF
--- a/visualizations/frontend/filters/TTagsSelector.vue
+++ b/visualizations/frontend/filters/TTagsSelector.vue
@@ -80,7 +80,7 @@
               <span
                 class="sticky top-0 left-0 w-full m-auto font-semibold text-left bg-white"
               >
-                Select a {{ selectedKey }}
+                Select a {{ itemValueLabel || selectedKey }}
               </span>
               <div v-if="tags[selectedKey] && tags[selectedKey].length">
                 <div
@@ -193,6 +193,10 @@ export default {
     searchFields: {
       type: Array,
       default: null,
+    },
+    itemValueLabel: {
+      type: String,
+      default: "",
     },
   },
   data: () => ({


### PR DESCRIPTION
### What this does

A feature requested by Kennan, in some cases we need a custom label to show up for values, with this prop default `value` name from sql layer will be replaced with provided text.

Sample: In this sample, default key name is replaced by `Custom label`.
<img width="282" alt="Screenshot 2023-06-26 at 7 26 00 PM" src="https://github.com/topcoat-data/topcoat-public/assets/43262405/673ba4ba-5b9c-4015-92a5-5725be5a6538">

### Notes for the reviewer

**Testing: Fastest way to test**
- Inside IDE for snyk-insights, switch the main branch to `feat/project-collections` from GIT manager tab.
- Add this public branch to config.yml inside IDE and build modules.
- Inside another tab open this [url](https://snyk-insights.topcoatdata.app/reporting/issues-detail?context[org]=754984a6-a968-42b6-ae7c-bf8761451518) that has org id context for above filter. 
- Go to `pages/issues_detail.html` file and find the filter that is using `filter_project_collections` layer.
- Add the prop to t-tags-selector and use any custom text value.
- Refresh the page and confirm the provided text now appears.

### Missed anything?

- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] Security aspects considered? Unhappy paths?
- [ ] Have you accounted for accessibility?
- [ ] Commit messages and bodies explain what and why?

### More information

- [Slack thread](https://snyk.slack.com/archives/)
- [Jira ticket](https://snyksec.atlassian.net/browse/TEAM-0000)

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots, including URL if applicable, for any front end change. GIFs are most welcome!_
