### PR TITLE
fix: Update sparkline on filters changed

### DIFF
--- a/visualizations/frontend/charts/sparkline.vue
+++ b/visualizations/frontend/charts/sparkline.vue
@@ -38,7 +38,7 @@ export default {
     },
     created() {
         if (this.datum && this.datum.length) {
-            this.fixedData = Array.isArray(this.datum) ? this.datum : JSON.parse(this.datum);
+            this.assignData();
         }
     },
     mounted() {
@@ -146,6 +146,9 @@ export default {
             this.$nextTick(() => {
                 this.createSparkline();
             });
+        },
+        assignData() {
+            this.fixedData = Array.isArray(this.datum) ? this.datum : JSON.parse(this.datum);
         },
         xAccessor(d) {
             return d.x;
@@ -282,6 +285,14 @@ export default {
             });
         }
     },
+    watch: {
+        datum(value, oldValue) {
+            if (value !== oldValue) {
+                this.assignData();
+                this.createSparkline();
+            }
+        }
+    }
 };
 </script>
 


### PR DESCRIPTION
### What this does

Make sparklines react to prop datum changes.


### More information
https://linear.app/snyk/issue/FP-1077/spark-lines-do-not-update-when-filters-are-changed


### Screenshots / GIFs

https://github.com/topcoat-data/topcoat-public/assets/1915140/71eff4df-f556-4201-b394-bd7e2caa9e20

