### PR TITLE
chore: improve number formatting in TBigNumber

### DIFF
--- a/visualizations/frontend/other/TBigNumber.vue
+++ b/visualizations/frontend/other/TBigNumber.vue
@@ -154,7 +154,7 @@ export default {
       if (!this.rows) {
         return null;
       }
-      
+
       return this.rows.length ? this.rows[0] : null;
     },
     value() {
@@ -215,14 +215,13 @@ export default {
       };
     },
     formatNumber({ value, rendered }) {
-      // If number is greater than 6 digits, format it.
       if (value > this.numberFormatLimit) {
-        let formatter = Intl.NumberFormat("en", { notation: "compact" });
-        return formatter.format(value);
+        return Intl.NumberFormat("en", { notation: "compact" }).format(
+          rendered
+        );
       }
 
-      // Else return default rendered value from sql.
-      return rendered;
+      return Intl.NumberFormat("en").format(rendered);
     },
   },
 };


### PR DESCRIPTION
### What this does

This addresses part of the criteria of the following ticket: https://linear.app/snyk/issue/FP-1073/add-in-comma-separation-for-numbers-1000-and-over-on-tables-and-big

This PR does NOT address the TTable cell where a number + sparkline happens. The formatting of that number will be tackled separately.


### More information

- [Linear ticket](https://linear.app/snyk/issue/FP-1073/add-in-comma-separation-for-numbers-1000-and-over-on-tables-and-big)

### Screenshots / GIFs
#### Before
<img width="954" alt="Screenshot 2023-07-24 at 16 06 33" src="https://github.com/topcoat-data/topcoat-public/assets/1307818/83a4a1e6-e475-4d4f-a05b-b6691248f631">


#### After
<img width="930" alt="Screenshot 2023-07-24 at 16 08 46" src="https://github.com/topcoat-data/topcoat-public/assets/1307818/f06f241e-d869-48f2-893b-08163d2cb278">

