### PR TITLE
feat: create number formatting component

### DIFF
--- a/library/components/TFormattedNumber.vue
+++ b/library/components/TFormattedNumber.vue
@@ -1,0 +1,29 @@
+<template>
+  <div>{{ formattedNumber }}</div>
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      type: Number,
+      required: true,
+    },
+    truncationLimit: {
+      type: Number,
+      default: 999999,
+    },
+  },
+  computed: {
+    formattedNumber() {
+      if (this.value > this.truncationLimit) {
+        return Intl.NumberFormat("en", { notation: "compact" }).format(
+          this.value
+        );
+      }
+
+      return Intl.NumberFormat("en").format(this.value);
+    },
+  },
+};
+</script>


### PR DESCRIPTION
### What this does

This PR adds a component to format numbers in a consistent way. The intention is to centralise the logic for formatting numbers that lives in t-big-number, into a simple component. This will allow report authors to get consistent number formatting wherever they use this component. It will replace the logic in `t-big-number` in a separate PR.

This component will format the number to the 'en' locale until it reaches a threshold, and then it will be formatted using the 'compact' notation.


### Notes for the reviewer

To test this component you can go follow the following steps
* Go to https://snyk-insights.topcoatdata.app/reporting/a/develop
* Go to the `config.yml` file and replace the branch for topcoat-public with this branch name: 

```
modules:
    - git: https://github.com/topcoat-data/topcoat-public.git
      revision: chore/formatted-number-component
```

* Save the changes to the config.yml file and click `Build and Sync Modules` (the cloud icon) in the left hand menu
* Use `t-formatted-number` in a report. Below is an example of usage in the `enterprise_analytics.html`

```
<t-column header="TOTAL OPEN" id-or-name="OPEN_ISSUES">
  <div class="flex items-center gap-4">
    <t-formatted-number :value="JSON.parse(value)[JSON.parse(value).length - 1]" />
    <sparkline 
      :datum="value" 
      wrapperless
      style="width: 46px; height:30px;"
      stroke="#727184"
    />
  </div>
</t-column>
```



### Missed anything?

- [ ] Documentation - not yet. Will add once approved.

### More information


- [Linear](https://linear.app/snyk/issue/FP-1073/add-in-comma-separation-for-numbers-1000-and-over-on-tables-and-big)

### Screenshots / GIFs

#### Before
<img width="1914" alt="Screenshot 2023-07-25 at 11 26 35" src="https://github.com/topcoat-data/topcoat-public/assets/1307818/fb25f7ee-0ce6-4442-9abf-de4ef59fecd1">

<img width="567" alt="Screenshot 2023-07-25 at 12 17 31" src="https://github.com/topcoat-data/topcoat-public/assets/1307818/189b2701-663e-4977-8119-77d1e011eeb7">


#### After
<img width="1903" alt="Screenshot 2023-07-25 at 11 21 43" src="https://github.com/topcoat-data/topcoat-public/assets/1307818/1aaafbba-6dd0-453f-8677-fe0404920b76">
<img width="682" alt="Screenshot 2023-07-25 at 11 20 32" src="https://github.com/topcoat-data/topcoat-public/assets/1307818/2309e3ef-10ef-4ed2-893d-ac4ca8a8d04c">




