### PR TITLE
fix: do not sort table when sort is disabled.

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -98,7 +98,8 @@
           :indeterminate.prop="someChecked"
         />
         <!-- Headings -->
-        <button
+        <component
+          :is="column.sort ? 'button' : 'div'"
           v-for="(column, index) in internalColumns"
           :key="column.header"
           :ref="'headerCell_' + index"
@@ -132,7 +133,7 @@
               <menu-swap-icon :size="20" class="unsortedIcon" />
             </slot>
           </span>
-        </button>
+        </component>
 
         <!-- No table data -->
         <div
@@ -477,7 +478,9 @@ export default {
   },
   computed: {
     computedHeight() {
-      return this.defaultHeight && !this.isDataAvailable ? `${this.defaultHeight}px` : "auto";
+      return this.defaultHeight && !this.isDataAvailable
+        ? `${this.defaultHeight}px`
+        : "auto";
     },
     isPdf() {
       return window.location.href.includes("/pdf?");

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -105,7 +105,7 @@
           :ref="'headerCell_' + index"
           class="cellPadding border-b border-[#D3D3D9] focus:outline-none focus-visible:ring flex items-center leading-[15px] text-[12px] text-[#555463] font-semibold tracking-[0.12em] uppercase"
           :class="generateHeaderClasses(column.property, index)"
-          @click="updateSort(column)"
+          v-on="column.sort ? { click: () => updateSort(column) } : {}"
         >
           <slot
             :name="generateSlotName('header', column.header)"


### PR DESCRIPTION
### What this does

Table headers were attempting to sort the table (and failing), even when the sort option was not set. 
This PR fixes that by making rendering a button/attaching a click handler conditional.

### Notes for the reviewer

To test this component:
* Go to https://snyk-insights.topcoatdata.app/reporting/a/develop
* Go to the `config.yml` file and replace the branch for topcoat-public with this branch name: 

```
modules:
    - git: https://github.com/topcoat-data/topcoat-public.git
      revision: fix/table-sort-condition
```

* Save the changes to the config.yml file and click `Build and Sync Modules` (the cloud icon) in the left hand menu
* Check tables across reports that have sorting on and sorting off.
* Ensure that tables without sorting do not attempt to sort on click of the header
* Ensure that sorting works as expected


### More information

- [Linear ticket](https://linear.app/snyk/issue/FP-1071/table-headers-are-clickable-on-tables-with-sorting-turned-off-and-a)

### Screenshots / GIFs
#### Before 
##### Sortable Column (Analytics Report, Exposure Tab)
<img width="1225" alt="Screenshot 2023-07-26 at 14 29 52" src="https://github.com/topcoat-data/topcoat-public/assets/1307818/3cc11f8d-d45b-4aec-80d2-d1059502b0f8">

##### Column without sort (Analytics Report, Manage Tab)
<img width="1233" alt="Screenshot 2023-07-26 at 14 30 09" src="https://github.com/topcoat-data/topcoat-public/assets/1307818/50a89fce-91af-48e4-9feb-508b1b3b7854">


#### After
##### Sortable Column (Analytics Report, Exposure Tab)
![after-sort](https://github.com/topcoat-data/topcoat-public/assets/1307818/d5b18f46-2367-4d34-b574-b788e4ab929c)

##### Column without sort (Analytics Report, Manage Tab)
![after](https://github.com/topcoat-data/topcoat-public/assets/1307818/51831831-b405-4da8-b748-9263d93cd60a)

