### PR TITLE
fix: Add xanchor config to line chart legends

### DIFF
--- a/visualizations/frontend/charts/line_chart.html
+++ b/visualizations/frontend/charts/line_chart.html
@@ -502,7 +502,9 @@
                 {% else %}
                 "y" : "1.1"
                 {% endif %},
-
+                {% if config.legend_x_anchor %}
+                "xanchor" : "{{ config.legend_x_anchor }}"
+                {% endif %},
                 {% if config.legend_orientation %}
                 "orientation" : "{{ config.legend_orientation }}"
                 {% else %}


### PR DESCRIPTION
### What this does

Fixed the legends positioning described here: https://linear.app/snyk/issue/FP-1101/visualization-meta-design-details

You have to pass the `legend_x_anchor` from the layer configuration to see this applied.

You can use this branch to test it: `chore/exposure-line-chart`

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, best to review commit-by-commit?, questions…_

### Missed anything?

- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] Security aspects considered? Unhappy paths?
- [ ] Have you accounted for accessibility?
- [ ] Commit messages and bodies explain what and why?

### More information

- [Slack thread](https://snyk.slack.com/archives/)
- [[Jira ticket](https://snyksec.atlassian.net/browse/TEAM-0000)
](https://linear.app/snyk/issue/FP-1101/visualization-meta-design-details)
### Screenshots / GIFs

Before

<img width="1832" alt="Screenshot 2023-07-26 at 19 43 33" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/8e422e31-512e-4f1e-9ce5-6c90506f9077">


After
<img width="1495" alt="Screenshot 2023-07-26 at 19 43 05" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/cad1b5b9-643e-4d92-a4bb-099c5e66ab76">
