### PR TITLE
Fix/line chart styles

### DIFF
--- a/visualizations/frontend/charts/line_chart.html
+++ b/visualizations/frontend/charts/line_chart.html
@@ -114,7 +114,7 @@
                     {% if config.font_family %}
                     "family" : "{{ config.title_font_family }}"
                     {% else %}
-                    "family": "Open Sans"
+                    "family": "Roboto"
                     {% endif %},
                     {% if config.title_font_color %}
                     "color" : "{{ config.title_font_color }}"
@@ -132,7 +132,7 @@
                 {% if config.font_family %}
                  "family" : "{{ config.font_family }}"
                 {% else %}
-                "family": "Open Sans"
+                "family": "Roboto"
                 {% endif %},
 
                 {% if config.font_color %}
@@ -178,7 +178,7 @@
                     {% if config.tickfont_family %}
                     "family" : "{{ config.tickfont_family }}"
                     {% else %}
-                    "family": "Open Sans"
+                    "family": "Roboto"
                     {% endif %},
 
                     {% if config.tickfont_color %}
@@ -206,7 +206,7 @@
                         {% if config.font_family %}
                         "family" : "{{ config.font_family }}"
                         {% else %}
-                        "family": "Open Sans"
+                        "family": "Roboto"
                         {% endif %},
                         {% if config.font_color %}
                         "color" : "{{ config.font_color }}"
@@ -254,7 +254,7 @@
                     {% if config.tickfont_family %}
                     "family" : "{{ config.tickfont_family }}"
                     {% else %}
-                    "family": "Open Sans"
+                    "family": "Roboto"
                     {% endif %},
 
                     {% if config.tickfont_color %}
@@ -279,7 +279,7 @@
                         {% if config.font_family %}
                         "family" : "{{ config.font_family }}"
                         {% else %}
-                        "family": "Open Sans"
+                        "family": "Roboto"
                         {% endif %},
                         {% if config.font_color %}
                         "color" : "{{ config.font_color }}"
@@ -328,7 +328,7 @@
                     {% if config.tickfont_family %}
                     "family" : "{{ config.tickfont_family }}"
                     {% else %}
-                    "family": "Open Sans"
+                    "family": "Roboto"
                     {% endif %},
 
                     {% if config.tickfont_color %}
@@ -356,7 +356,7 @@
                         {% if config.font_family %}
                         "family" : "{{ config.font_family }}"
                         {% else %}
-                        "family": "Open Sans"
+                        "family": "Roboto"
                         {% endif %},
                         {% if config.font_color %}
                         "color" : "{{ config.font_color }}"
@@ -406,7 +406,7 @@
                     {% if config.tickfont_family %}
                     "family" : "{{ config.tickfont_family }}"
                     {% else %}
-                    "family": "Open Sans"
+                    "family": "Roboto"
                     {% endif %},
 
                     {% if config.tickfont_color %}
@@ -434,7 +434,7 @@
                         {% if config.font_family %}
                         "family" : "{{ config.font_family }}"
                         {% else %}
-                        "family": "Open Sans"
+                        "family": "Roboto"
                         {% endif %},
                         {% if config.font_color %}
                         "color" : "{{ config.font_color }}"
@@ -466,7 +466,7 @@
                     {% if config.hover_font_family %}
                     "family" : "{{ config.hover_font_family }}"
                     {% else %}
-                    "family": "Open Sans"
+                    "family": "Roboto"
                     {% endif %},
                     {% if config.hover_font_color %}
                     "color" : "{{ config.hover_font_color }}"
@@ -517,7 +517,7 @@
                     {% if config.legend_font_family %}
                     "family" : "{{ config.legend_font_family }}"
                     {% else %}
-                    "family": "Open Sans"
+                    "family": "Roboto"
                     {% endif %},
                     {% if config.legend_font_color %}
                     "color" : "{{ config.legend_font_color }}"

--- a/visualizations/frontend/charts/line_chart.html
+++ b/visualizations/frontend/charts/line_chart.html
@@ -495,7 +495,7 @@
                 {% if config.legend_x %}
                 "x" : "{{ config.legend_x }}"
                 {% else %}
-                "x" : "0.01"
+                "x" : "1"
                 {% endif %},
                 {% if config.legend_y %}
                 "y" : "{{ config.legend_y }}"

--- a/visualizations/frontend/charts/line_chart.html
+++ b/visualizations/frontend/charts/line_chart.html
@@ -502,7 +502,11 @@
                 {% else %}
                 "y" : "1.1"
                 {% endif %},
-
+                {% if config.legend_x_anchor %}
+                "xanchor" : "{{ config.legend_x_anchor }}"
+                {% else %}
+                "xanchor" : "right"
+                {% endif %},
                 {% if config.legend_orientation %}
                 "orientation" : "{{ config.legend_orientation }}"
                 {% else %}

--- a/visualizations/frontend/charts/line_chart.html
+++ b/visualizations/frontend/charts/line_chart.html
@@ -260,7 +260,7 @@
                     {% if config.tickfont_color %}
                     "color" : "{{ config.tickfont_color }}"
                     {% else %}
-                    "color" : "#161F3D"
+                    "color" : "#A3A3A3"
                     {% endif %},
 
                     {% if config.tickfont_size %}
@@ -334,7 +334,7 @@
                     {% if config.tickfont_color %}
                     "color" : "{{ config.tickfont_color }}"
                     {% else %}
-                    "color" : "#161F3D"
+                    "color" : "#A3A3A3"
                     {% endif %},
 
                     {% if config.tickfont_size %}
@@ -412,7 +412,7 @@
                     {% if config.tickfont_color %}
                     "color" : "{{ config.tickfont_color }}"
                     {% else %}
-                    "color" : "#161F3D"
+                    "color" : "#A3A3A3"
                     {% endif %},
 
                     {% if config.tickfont_size %}

--- a/visualizations/frontend/charts/line_chart.html
+++ b/visualizations/frontend/charts/line_chart.html
@@ -184,7 +184,7 @@
                     {% if config.tickfont_color %}
                     "color" : "{{ config.tickfont_color }}"
                     {% else %}
-                    "color" : "#161F3D"
+                    "color" : "#A3A3A3"
                     {% endif %},
 
                     {% if config.tickfont_size %}


### PR DESCRIPTION
### What this does

Improve line chart styles according to Figma designs.

### Notes for the reviewer

Use this branch from topcoat-reports: `fix/line-chart-styles`
You have to update the config.yml to point to: `fix/line-chart-styles`


### More information

- [Slack thread](https://snyk.slack.com/archives/)
- [Jira ticket](https://snyksec.atlassian.net/browse/TEAM-0000)

### Screenshots / GIFs

Before:
<img width="1263" alt="Screenshot 2023-07-27 at 12 06 31" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/20d69a5b-8386-4d79-a6f7-ea06b01c1a6e">

<img width="1271" alt="Screenshot 2023-07-27 at 12 06 38" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/50f16fd1-35b5-46d4-8a00-a6e163c87efd">

<img width="1284" alt="Screenshot 2023-07-27 at 12 06 43" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/ca107aab-846f-4acb-972f-7a179fc733d1">

<img width="1277" alt="Screenshot 2023-07-27 at 12 06 48" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/c0973fd2-e1e9-4981-94ad-9be261b834cf">


After:
<img width="1498" alt="Screenshot 2023-07-27 at 12 03 38" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/b045d954-2dcf-4774-81b1-4a690355bb7f">

<img width="1497" alt="Screenshot 2023-07-27 at 12 03 45" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/cd6f4342-2530-4d58-aaee-5d4f2030cefe">


<img width="1499" alt="Screenshot 2023-07-27 at 12 03 54" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/8fb5acd9-ba0d-4a96-b7d9-601223d51e22">

<img width="1495" alt="Screenshot 2023-07-27 at 12 04 01" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/e3c80b8d-4a80-4252-a738-f60760fd0c9c">


