### PR TITLE
chore: implement tab hover states

### DIFF
--- a/visualizations/frontend/other/TBigNumber.vue
+++ b/visualizations/frontend/other/TBigNumber.vue
@@ -100,7 +100,7 @@ export default {
     },
     textColor: {
       type: String,
-      default: "#393842",
+      default: "inherit",
     },
     tValueColumn: {
       type: String,
@@ -140,7 +140,7 @@ export default {
     },
     numberTextColor: {
       type: String,
-      default: "#393842",
+      default: "inherit",
     },
     customClass: {
       type: String,

--- a/visualizations/frontend/other/TTabs.vue
+++ b/visualizations/frontend/other/TTabs.vue
@@ -4,7 +4,7 @@
       <div
         v-for="tab in tabs"
         :key="tab"
-        class="cursor-pointer border-t-4"
+        class="pb-2 cursor-pointer border-t-4"
         :class="
           activeTab === tab.slot
             ? 'bg-white border-[#145DEB]'
@@ -12,9 +12,18 @@
         "
         @click="switchTab(tab)"
       >
-        <slot :name="['tab_' + tab.slot]" :tab="tab">
-          {{ tab.label }}
-        </slot>
+        <div
+          class="p-6 min-w-[240px] border-2 rounded-md border-transparent"
+          :class="
+            activeTab === tab.slot
+              ? 'text-[#1c1c21]'
+              : 'hover:border-[#d3d3d980] hover:bg-[#F2F1F4] hover:text-[#1c1c21] text-[#555463]'
+          "
+        >
+          <slot :name="['tab_' + tab.slot]" :tab="tab">
+            {{ tab.label }}
+          </slot>
+        </div>
       </div>
     </div>
     <div :key="activeTab">


### PR DESCRIPTION
### What this does

This PR adds the hover styling to the tabs as per the following ticket

https://linear.app/snyk/issue/FP-1099/tab-nav-styling-hover-state


### Notes for the reviewer


To test this component:
* Go to https://snyk-insights.topcoatdata.app/reporting/a/develop
* Checkout the git branch for topcoat-reports that accompanies this change: https://github.com/snyk/topcoat-reports/pull/369
* Go to the `config.yml` file and replace the branch for topcoat-public with this branch name: 

```
modules:
    - git: https://github.com/topcoat-data/topcoat-public.git
      revision: feat/tabs-hover-sytles
```

* Save the changes to the config.yml file and click `Build and Sync Modules` (the cloud icon) in the left hand menu
* Check that the hover styles closely resemble what is specified in the ticket
* Check big number across reports. Please report any regressions and they will be addressed.


Note: We **cannot accommodate the font-weight changes to the number YET.** We would need to do that at a later stage.


### More information

https://linear.app/snyk/issue/FP-1099/tab-nav-styling-hover-state

### Screenshots / GIFs

![2023-07-27 16 30 33](https://github.com/topcoat-data/topcoat-public/assets/1307818/cde3e014-8a21-453c-aa10-6fcb71b79697)

