### PR TITLE
fix: Add margin-left to the first header cell in TTable

### DIFF
--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -103,7 +103,7 @@
           v-for="(column, index) in internalColumns"
           :key="column.header"
           :ref="'headerCell_' + index"
-          class="cellPadding border-b border-[#D3D3D9] focus:outline-none focus-visible:ring flex items-center leading-[15px] text-[12px] text-[#555463] font-semibold tracking-[0.12em] uppercase"
+          class="first:ml-3 cellPadding border-b border-[#D3D3D9] focus:outline-none focus-visible:ring flex items-center leading-[15px] text-[12px] text-[#555463] font-semibold tracking-[0.12em] uppercase"
           :class="generateHeaderClasses(column.property, index)"
           v-on="column.sort ? { click: () => updateSort(column) } : {}"
         >


### PR DESCRIPTION
### What this does

Add margin-left to the first header cell to be aligned with the margin of the rows.

### Notes for the reviewer

Use this branch `fix/table-headers-paddings` on any topcoat-insights branch to see the changes.


### More information

https://linear.app/snyk/issue/FP-1103/padding-of-table-headers-misaligned

### Screenshots / GIFs

|Before|After|
|---|---|
|<img width="633" alt="Screenshot 2023-07-27 at 17 55 39" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/ef6e96fe-9680-454b-adbb-a64d011394a0">|<img width="1025" alt="Screenshot 2023-07-27 at 17 55 46" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/f92f9b41-19da-4688-beae-db35c083f2cb">|
|<img width="766" alt="Screenshot 2023-07-27 at 17 54 25" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/ed393df8-67af-48c1-b597-494b61b9be41">|<img width="786" alt="Screenshot 2023-07-27 at 17 54 05" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/63279a08-9ec7-492a-a383-01719cf0fdd4">|

