### PR TITLE
ajax request watcher and pdf component changes

### DIFF
--- a/library/components/TPdf.vue
+++ b/library/components/TPdf.vue
@@ -45,6 +45,10 @@ export default {
       type: Object,
       default: {},
     },
+    timeout: {
+      type: Number,
+      default: 300,
+    },
   },
   data: () => ({
     showTooltip: false,
@@ -52,7 +56,7 @@ export default {
   methods: {
     downloadPdf() {
       const url = this.page.url + window.location.search;
-      this.downloadPdfFile(url, this.options);
+      this.downloadPdfFile(url, { pdf: this.options, timeout: this.timeout });
       this.trackExport("pdf");
     },
   },

--- a/library/components/TPdfDownloadHelper.vue
+++ b/library/components/TPdfDownloadHelper.vue
@@ -1,0 +1,38 @@
+<template>
+  <div v-if="isVisible" id="seleniumComponent" class="fixed top-0 bottom-0" />
+</template>
+
+<script>
+export default {
+  data: () => ({
+    responses: 0,
+    isVisible: false,
+  }),
+  watch: {
+    responses: _.debounce(function (newVal) {
+      this.showSeleniumComponent();
+    }, 1000),
+  },
+  created() {
+    this.countAjaxResponses();
+  },
+  methods: {
+    countAjaxResponses() {
+      var $this = this;
+      axios.interceptors.response.use(
+        function (response) {
+          $this.responses += 1;
+          return response;
+        },
+        function (error) {
+          $this.responses += 1;
+          return Promise.reject(error);
+        }
+      );
+    },
+    showSeleniumComponent() {
+      this.isVisible = true;
+    },
+  },
+};
+</script>

--- a/library/components/TPdfDownloadHelper.vue
+++ b/library/components/TPdfDownloadHelper.vue
@@ -21,11 +21,15 @@ export default {
       var $this = this;
       axios.interceptors.response.use(
         function (response) {
-          $this.responses += 1;
+          if (response.config.url.includes("/api/layers")) {
+            $this.responses += 1;
+          }
           return response;
         },
         function (error) {
-          $this.responses += 1;
+          if (error.config.url.includes("/api/layers")) {
+            $this.responses += 1;
+          }
           return Promise.reject(error);
         }
       );


### PR DESCRIPTION
### What this does

**Problem**
PDF Download fails on long pages, I came up with 2 fixes, one allows for increased timeout for ajax request while other replaces the backend's time.sleep(1) with axios interceptor that can track ongoing requests and signal the backend's selenium to capture the page when requests stop.

Interceptor will watch the layer requests that get fired every 250ms by frontend until layer gets the response.

1. t-pdf: Component will be able to handle ajax request's timeout from a prop (timeout=300).
2. t-pdf-download-helper: Will intercept axios to watch for layer requests, as soon as they stop it will show a component in DOM that selenium in backend will be watching for.

### Notes for the reviewer

Instructions added to backend [PR](https://github.com/snyk/topcoat-core/pull/728), only for local testing.

### Missed anything?

- [ ] Performance (customer with 200k users, customer with 1k orgs etc). Review the [Performance documentation](https://www.notion.so/snyk/Performance-Scale-761d05cf918446c6be9292686c4f3f29)
- [ ] Security aspects considered? Unhappy paths?
- [ ] Have you accounted for accessibility?
- [ ] Commit messages and bodies explain what and why?

### More information

- [Slack thread](https://snyk.slack.com/archives/)
- [Jira ticket](https://snyksec.atlassian.net/browse/TEAM-0000)

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots, including URL if applicable, for any front end change. GIFs are most welcome!_
