### PR TITLE
feat: add max height for multiselect dropdown

### DIFF
--- a/visualizations/frontend/filters/v2/TMultiSelector.vue
+++ b/visualizations/frontend/filters/v2/TMultiSelector.vue
@@ -99,7 +99,7 @@
       <div class="px-[12px] pt-[4px] pb-[6px] w-full">
         <virtual-list
           :style="{
-            height: Math.min(menu.length * 30, 320) + 'px',
+            height: Math.min(menu.length * 30, listMaxHeight) + 'px',
             'overflow-y': 'auto',
           }"
           :estimate-size="32"
@@ -212,6 +212,10 @@ export default {
       type: Number,
       default: 5,
     },
+    listMaxHeight: {
+      type: Number,
+      default: 320,
+    }
   },
   data: () => ({
     checked: [],


### PR DESCRIPTION
This PR adds a `listMaxHeight` to the MultiSelect component.

The use case is, sometimes the filter is in a card which has a height restriction. When the height of the filter exceeds the card height, it causes weird UI effect.

Example UI issue see [thread](https://snyk.slack.com/archives/C03NR9J9P4Z/p1700754900841889)

With this prop we could then force the org filter not to exceed outer component height.