### PR TITLE
fix: Unset filters when report page changes

### DIFF
--- a/library/components/TNavigationDropdown.vue
+++ b/library/components/TNavigationDropdown.vue
@@ -122,6 +122,8 @@ export default {
   },
   methods: {
     redirectToPage(e, page) {
+      this.unsetAllFilters();
+
       if (e.metaKey || e.ctrlKey) {
         window.open(page.url, "_blank");
       } else if (e.shiftKey) {


### PR DESCRIPTION
### What this does

Reset filters when the report is changed from the dropdown.
Once this PR is merged, we can update topcoat-reports with latest topcoat-core and topcoat-public to work on AppUI to use the new message sent by the children (iframed) page to AppUI.

### Notes for the reviewer

1. Set this revision on the topcoat-reports config file on snyk-insights:
```code
       revision: fix/report-page-changed
```
2. Build & Sync modules
3. Nothing should break or change since old reporting will do a full page reload between report page changes.

### More information

https://snyksec.atlassian.net/browse/FP-135