### PR TITLE
fix: disable export to csv when there is not data

### DIFF
--- a/library/components/TCsvExport.vue
+++ b/library/components/TCsvExport.vue
@@ -2,10 +2,10 @@
   <button
     class="rounded cursor-pointer border-1 border-[#C3C2CB] text-[#555463] bg-white w-max p-1"
     style="height: fit-content"
-    :disabled="is_loading"
+    :disabled="is_loading || disabled"
     @click="download"
   >
-    <div class="flex items-center gap-1">
+    <div class="flex items-center gap-1" :class="{ disabled }">
       <t-loading-spinner v-if="is_loading" position="relative" />
       <download-outline-icon v-else :size="18" />
       {{ label }}
@@ -28,6 +28,10 @@ export default {
     additionalFilters: {
       type: Object,
       default: () => {},
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
     },
   },
   data: () => ({
@@ -73,3 +77,13 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+button:disabled,
+.disabled {
+  background-color: #f2f1f4;
+  border-color: transparent;
+  color: #b3b2bd;
+  cursor: default;
+}
+</style>

--- a/visualizations/frontend/other/TTable.vue
+++ b/visualizations/frontend/other/TTable.vue
@@ -43,6 +43,7 @@
           :t-layer="layer"
           :additional-filters="additionalFilters"
           class="csvExportButton"
+          :disabled="totalRows === 0"
         />
         <TSearch
           v-if="canSearch"


### PR DESCRIPTION
### What this does

When there is not data, the CSV download process fails. In order to avoid this, we disable the button until there are results.

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, best to review commit-by-commit?, questions…_

### More information

https://linear.app/snyk/issue/FP-1788/nosuchkey-displayed-when-downloading-csv-from-reports-page

### Screenshots / GIFs

Enabled:
<img width="356" alt="image" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/1629adeb-73db-49e6-81d0-31185558c03e">


Disabled:
<img width="342" alt="image" src="https://github.com/topcoat-data/topcoat-public/assets/1915140/8d46edbf-81c7-4899-832c-59bf64ca7449">



